### PR TITLE
Add HTTPS support for kubernetes API

### DIFF
--- a/charts/healthz/README.md
+++ b/charts/healthz/README.md
@@ -27,6 +27,7 @@ The following tables lists the configurable parameters of the Healthz chart and 
 | `healthz.debug`               | Enable/disable debug log level                             | `true`                                        |
 | `healthz.checkinterval`       | K8S and ETCD services check interval (Go duration format)  | `1m`                                          |
 | `healthz.kube.addr`           | K8S API endpoint                                           | `http://localhost:8080`                       |
+| `healthz.kube.cert`           | K8S API SSL cert path                                      | ``                                            |
 | `healthz.kube.nodesThreshold` | Lower limit of number of K8S nodes available               | `3`                                           |
 | `healthz.image.repo`          | Image repo                                                 | `quay.io/gravitational/satellite`             |
 | `healthz.image.tag`           | Image tag                                                  | `stable`                                      |

--- a/charts/healthz/templates/deployment.yaml
+++ b/charts/healthz/templates/deployment.yaml
@@ -60,6 +60,10 @@ spec:
               value: {{.Values.healthz.checkInterval | default "1m"}}
             - name: HEALTH_KUBE_ADDR
               value: {{.Values.healthz.kube.addr | default ""}}
+{{if .Values.healthz.kube.cert}}
+            - name: HEALTH_KUBE_CERT_FILE
+              value: {{.Values.healthz.kube.cert | default ""}}
+{{end}}
             - name: HEALTH_KUBE_NODES_THRESHOLD
               value: {{.Values.healthz.kube.nodesThreshold | default "3" | quote}}
             - name: HEALTH_ACCESS_KEY

--- a/charts/healthz/values.yaml
+++ b/charts/healthz/values.yaml
@@ -10,6 +10,7 @@ healthz:
   nodeSelector: {}
   kube:
     addr: "http://localhost:8080"
+    cert: ""
     nodesThreshold: "3"
   image:
     repo: "quay.io/gravitational/satellite"

--- a/cmd/healthz/main.go
+++ b/cmd/healthz/main.go
@@ -105,6 +105,12 @@ func run() error {
 		listener = tls.NewListener(listener, tlsConfig)
 	}
 
+	if len(cfg.KubeCertFile) > 0 {
+		if err := utils.AddCertToDefaultPool(cfg.KubeCertFile); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
 	go func() {
 		if err := http.Serve(listener, nil); err != nil {
 			errChan <- trace.Wrap(err)

--- a/healthz/config/cli.go
+++ b/healthz/config/cli.go
@@ -36,6 +36,7 @@ func ParseCLIFlags(cfg *Config) {
 	kingpin.Flag("key-file", "Path to TLS key file.").Envar("HEALTH_KEY_FILE").StringVar(&cfg.KeyFile)
 	kingpin.Flag("ca-file", "Path to TLS CA file.").Envar("HEALTH_CA_FILE").StringVar(&cfg.CAFile)
 	kingpin.Flag("kube-addr", "K8S apiserver address.").Default("http://localhost:8080").Envar("HEALTH_KUBE_ADDR").StringVar(&cfg.KubeAddr)
+	kingpin.Flag("kube-cert-file", "K8S apiserver TLS cert file.").Envar("HEALTH_KUBE_CERT_FILE").StringVar(&cfg.KubeCertFile)
 	kingpin.Flag("kube-nodes-threshold", "Minimal limit of K8S nodes must be ready to assume cluster is healthy").Required().Envar("HEALTH_KUBE_NODES_THRESHOLD").IntVar(&cfg.KubeNodesThreshold)
 	etcdEndpoints := kingpin.Flag("etcd-addr", "Etcd machine address.").Default("http://localhost:4001,http://localhost:2380").Envar("ETCDCTL_PEERS").String()
 	kingpin.Flag("etcd-cert-file", "Path to etcd TLS cert file.").Envar("ETCDCTL_CERT_FILE").StringVar(&cfg.ETCDConfig.CertFile)

--- a/healthz/config/config.go
+++ b/healthz/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	CheckInterval      time.Duration
 	AccessKey          string
 	KubeAddr           string
+	KubeCertFile       string
 	KubeNodesThreshold int
 	ETCDConfig         monitoring.ETCDConfig
 	CertFile           string

--- a/healthz/utils/tls.go
+++ b/healthz/utils/tls.go
@@ -53,7 +53,7 @@ func CertFromFilePair(certFile, keyFile string) (*tls.Certificate, error) {
 	return &cert, err
 }
 
-// AddCertToDefaultPool adds certificate to from file to default pool
+// AddCertToDefaultPool adds certificate from file to default pool
 func AddCertToDefaultPool(fpath string) error {
 	certBytes, err := ioutil.ReadFile(fpath)
 	if err != nil {
@@ -64,7 +64,7 @@ func AddCertToDefaultPool(fpath string) error {
 		ClientCAs: x509.NewCertPool(),
 	}
 	if ok := tr.TLSClientConfig.ClientCAs.AppendCertsFromPEM(certBytes); !ok {
-		return trace.Wrap(trace.BadParameter("failed to load PEM %s", fpath))
+		return trace.BadParameter("failed to load PEM %s", fpath)
 	}
 	return nil
 }


### PR DESCRIPTION
I went the easy way: without modifications to monitoring package, adding certs to default cert pool.