### PR TITLE
Add an option to specify a CA certificate file

### DIFF
--- a/agent/server.go
+++ b/agent/server.go
@@ -70,15 +70,15 @@ func (r *server) LocalStatus(ctx context.Context, req *pb.LocalStatusRequest) (r
 }
 
 // newRPCServer creates an agent RPC endpoint for each provided listener.
-func newRPCServer(agent *agent, certFile, keyFile string, rpcAddrs []string) (*server, error) {
+func newRPCServer(agent *agent, caFile, certFile, keyFile string, rpcAddrs []string) (*server, error) {
 	creds, err := credentials.NewServerTLSFromFile(certFile, keyFile)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to read certificate/key from %v/%v", certFile, keyFile)
 	}
 
-	healthzHandler, err := newHealthHandler(certFile)
+	healthzHandler, err := newHealthHandler(caFile)
 	if err != nil {
-		return nil, trace.Wrap(err, "failed to read certificate from %v", certFile)
+		return nil, trace.Wrap(err, "failed to read CA certificate from %v", caFile)
 	}
 
 	backend := grpc.NewServer(grpc.Creds(creds))

--- a/agent/server_test.go
+++ b/agent/server_test.go
@@ -315,7 +315,8 @@ func (r *AgentSuite) newRemoteNode(node string, rpcPort int, members []serf.Memb
 	err := agent.Start()
 	c.Assert(err, IsNil)
 
-	server, err := newRPCServer(agent, r.certFile, r.keyFile, []string{addr})
+	// Use the same CA certificate for client and server
+	server, err := newRPCServer(agent, r.certFile, r.certFile, r.keyFile, []string{addr})
 	c.Assert(err, IsNil)
 
 	agent.rpc = server

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -70,15 +70,16 @@ func run() error {
 		cagentInfluxUsername = cagent.Flag("influxdb-user", "Username to use for connection").OverrideDefaultFromEnvar(EnvInfluxUser).String()
 		cagentInfluxPassword = cagent.Flag("influxdb-password", "Password to use for connection").OverrideDefaultFromEnvar(EnvInfluxPassword).String()
 		cagentInfluxURL      = cagent.Flag("influxdb-url", "URL of the InfluxDB endpoint").OverrideDefaultFromEnvar(EnvInfluxURL).String()
-		cagentCertFile       = cagent.Flag("cert-file", "TLS certificate for server RPC").ExistingFile()
-		cagentKeyFile        = cagent.Flag("key-file", "TLS certificate key for server RPC").ExistingFile()
+		cagentCAFile         = cagent.Flag("ca-file", "SSL CA certificate for verifying server certificates").ExistingFile()
+		cagentCertFile       = cagent.Flag("cert-file", "SSL certificate for server RPC").ExistingFile()
+		cagentKeyFile        = cagent.Flag("key-file", "SSL certificate key for server RPC").ExistingFile()
 
 		// `status` command
 		cstatus            = app.Command("status", "Query cluster status")
 		cstatusRPCPort     = cstatus.Flag("rpc-port", "Local agent RPC port").Default("7575").Int()
 		cstatusPrettyPrint = cstatus.Flag("pretty", "Pretty-print the output").Bool()
 		cstatusLocal       = cstatus.Flag("local", "Query the status of the local node").Bool()
-		cstatusCertFile    = cstatus.Flag("cert-file", "Client certificate for RPC").ExistingFile()
+		cstatusCertFile    = cstatus.Flag("cert-file", "Client SSL certificate file for RPC. This should be the CA certificate if the server certificates are signed by a CA").ExistingFile()
 
 		// checks command
 		cchecks = app.Command("checks", "Run local compatibility checks")
@@ -138,6 +139,7 @@ func run() error {
 			MetricsAddr: *cagentMetricsAddr,
 			Tags:        *cagentTags,
 			Cache:       multiplex.New(cache, backends...),
+			CAFile:      *cagentCAFile,
 			CertFile:    *cagentCertFile,
 			KeyFile:     *cagentKeyFile,
 		}


### PR DESCRIPTION
Had to make some changes to build proper `TLS` config with a `CA` certificate - otherwise nodes with certificates signed by a `CA` won't connect.