### PR TITLE
Set the HTTP status code depending on the cluster status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,7 @@ sloccount:
 	find . -path ./vendor -prune -o -name "*.go" -print0 | xargs -0 wc -l
 
 test:
-	go test -test.parallel=0 -race ./agent/...
-	go test -test.parallel=0 -race ./monitoring/...
+	go test -test.parallel=0 -race ./...
 
 test-style:
 	@scripts/validate-license.sh

--- a/agent/server.go
+++ b/agent/server.go
@@ -116,7 +116,12 @@ func newHealthHandler(certFile string) (http.HandlerFunc, error) {
 			return
 		}
 
-		roundtrip.ReplyJSON(w, http.StatusOK, status)
+		httpStatus := http.StatusOK
+		if isDegraded(*status) {
+			httpStatus = http.StatusServiceUnavailable
+		}
+
+		roundtrip.ReplyJSON(w, httpStatus, status)
 	}, nil
 }
 

--- a/agent/status.go
+++ b/agent/status.go
@@ -63,3 +63,11 @@ func nodeToSystemStatus(status pb.NodeStatus_Type) pb.SystemStatus_Type {
 		return pb.SystemStatus_Unknown
 	}
 }
+
+func isDegraded(status pb.SystemStatus) bool {
+	switch status.Status {
+	case pb.SystemStatus_Unknown, pb.SystemStatus_Degraded:
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Set the HTTP status code depending on the cluster status - e.g. use ServiceStatusUnavailable for degraded cluster state.
Add agent HTTP query test.

Updates https://github.com/gravitational/gravity/issues/2976.