### PR TITLE
Add check for fs.may_detach_mounts not being set

### DIFF
--- a/monitoring/local_linux.go
+++ b/monitoring/local_linux.go
@@ -28,6 +28,7 @@ func BasicCheckers() *compositeChecker {
 			DefaultOSChecker(),
 			NewIPForwardChecker(),
 			NewBridgeNetfilterChecker(),
+			NewMayDetachMountsChecker(),
 			DefaultProcessChecker(),
 			DefaultPortChecker(),
 			DefaultBootConfigParams(),

--- a/monitoring/sysctl.go
+++ b/monitoring/sysctl.go
@@ -40,6 +40,8 @@ type SysctlChecker struct {
 	OnMissing string
 	// OnValueMismatch is description when parameter value is not equal to expected
 	OnValueMismatch string
+	// SkipNotFound will skip reporting a sysctl that is not found on the system
+	SkipNotFound bool
 }
 
 // Name returns name of checker
@@ -68,7 +70,9 @@ func (c *SysctlChecker) Check(ctx context.Context, reporter health.Reporter) {
 	}
 
 	if trace.IsNotFound(err) {
-		reporter.Add(NewProbeFromErr(c.CheckerName, c.OnMissing, trace.Wrap(err)))
+		if !c.SkipNotFound {
+			reporter.Add(NewProbeFromErr(c.CheckerName, c.OnMissing, trace.Wrap(err)))
+		}
 		return
 	}
 

--- a/monitoring/sysctl_checkers.go
+++ b/monitoring/sysctl_checkers.go
@@ -37,3 +37,18 @@ func NewBridgeNetfilterChecker() *SysctlChecker {
 		OnValueMismatch: "kubernetes requires net.bridge.bridge-nf-call-iptables sysctl set to 1, https://www.gravitational.com/docs/faq/#bridge-driver",
 	}
 }
+
+// NewMayDetachMountsChecker checks if fs.may_detach_mounts is set
+// On RHEL 7.4 based kernels, device removals may fail with "device or resource busy" if fs.may_detach_mounts isn't set
+// Under kubernetes this can cause pods to get stuck in the terminating state
+// Docker issue: https://github.com/moby/moby/issues/22260
+// Docker will be setting the option on startup: https://github.com/moby/moby/pull/34886/files
+func NewMayDetachMountsChecker() *SysctlChecker {
+	return &SysctlChecker{
+		CheckerName:     "may-detach-mounts",
+		Param:           "fs.may_detach_mounts",
+		Expected:        "1",
+		OnValueMismatch: "On RHEL 7.4 or newer based kernels, fs.may_detach_mounts should be set to 1 or pods may get stuck in the Terminating state",
+		SkipNotFound:    true, // It appears that this setting may not appear in non RHEL or older kernels, so don't fire the alert if we don't find the setting
+	}
+}

--- a/monitoring/sysctl_checkers.go
+++ b/monitoring/sysctl_checkers.go
@@ -48,7 +48,7 @@ func NewMayDetachMountsChecker() *SysctlChecker {
 		CheckerName:     "may-detach-mounts",
 		Param:           "fs.may_detach_mounts",
 		Expected:        "1",
-		OnValueMismatch: "On RHEL 7.4 or newer based kernels, fs.may_detach_mounts should be set to 1 or pods may get stuck in the Terminating state",
+		OnValueMismatch: "fs.may_detach_mounts should be set to 1 or pods may get stuck in the Terminating state, see https://www.gravitational.com/docs/faq/#kubernetes-pods-stuck-in-terminating-state",
 		SkipNotFound:    true, // It appears that this setting may not appear in non RHEL or older kernels, so don't fire the alert if we don't find the setting
 	}
 }


### PR DESCRIPTION
We encountered an issue on RHEL 7.4 based kernels where pods could get stuck in the terminating state. It appears this is related to the following docker issue: https://github.com/moby/moby/issues/22260

Docker has decided to set the sysctl on startup, but older versions of docker will not do this. I've also added a directive to not report an error if the sysctl option isn't found. Based on the comments in https://github.com/moby/moby/pull/34886/files not all kernels will have this particular sysctl key, so we don't want to report errors if the key isn't on the particular kernel version which won't have this issue.

Cheers,