### PR TITLE
Unexport checker types that require non-trivial initialization

### DIFF
--- a/monitoring/boot_config_linux.go
+++ b/monitoring/boot_config_linux.go
@@ -34,16 +34,16 @@ import (
 
 // NewBootConfigParamChecker returns a new checker that verifies
 // kernel configuration options
-func NewBootConfigParamChecker(params ...BootConfigParam) *BootConfigParamChecker {
-	return &BootConfigParamChecker{
+func NewBootConfigParamChecker(params ...BootConfigParam) health.Checker {
+	return &bootConfigParamChecker{
 		Params:              params,
 		kernelVersionReader: realKernelVersionReader,
 		bootConfigReader:    realBootConfigReader,
 	}
 }
 
-// BootConfigParamChecker checks whether parameters provided are specified in linux boot configuration file
-type BootConfigParamChecker struct {
+// bootConfigParamChecker checks whether parameters provided are specified in linux boot configuration file
+type bootConfigParamChecker struct {
 	// Params is array of parameters to check for
 	Params []BootConfigParam
 	kernelVersionReader
@@ -59,12 +59,12 @@ type BootConfigParam struct {
 }
 
 // Name returns name of the checker
-func (c *BootConfigParamChecker) Name() string {
+func (c *bootConfigParamChecker) Name() string {
 	return bootConfigParamID
 }
 
 // Check parses boot config files and validates whether parameters provided are set
-func (c *BootConfigParamChecker) Check(ctx context.Context, reporter health.Reporter) {
+func (c *bootConfigParamChecker) Check(ctx context.Context, reporter health.Reporter) {
 	release, err := c.kernelVersionReader()
 	if err != nil {
 		reporter.Add(NewProbeFromErr(bootConfigParamID,
@@ -132,7 +132,7 @@ func (c *BootConfigParamChecker) Check(ctx context.Context, reporter health.Repo
 }
 
 // DefaultBootConfigParams returns standard kernel configs required for running kubernetes
-func DefaultBootConfigParams() *BootConfigParamChecker {
+func DefaultBootConfigParams() health.Checker {
 	return NewBootConfigParamChecker(
 		BootConfigParam{Name: "CONFIG_NET_NS"},
 		BootConfigParam{Name: "CONFIG_PID_NS"},
@@ -170,7 +170,7 @@ func DefaultBootConfigParams() *BootConfigParamChecker {
 }
 
 // GetStorageDriverBootConfigParams returns config params required for a given filesystem
-func GetStorageDriverBootConfigParams(drv string) *BootConfigParamChecker {
+func GetStorageDriverBootConfigParams(drv string) health.Checker {
 	var params []BootConfigParam
 
 	switch drv {
@@ -183,7 +183,7 @@ func GetStorageDriverBootConfigParams(drv string) *BootConfigParamChecker {
 		params = append(params, BootConfigParam{Name: "CONFIG_OVERLAY_FS"})
 	}
 
-	return &BootConfigParamChecker{Params: params}
+	return NewBootConfigParamChecker(params...)
 }
 
 // KernelConstraintFunc is a function to determine if the kernel version

--- a/monitoring/boot_config_linux_test.go
+++ b/monitoring/boot_config_linux_test.go
@@ -115,9 +115,11 @@ func (*MonitoringSuite) TestValidatesBootConfig(c *C) {
 
 	// exercise / verify
 	for _, testCase := range testCases {
-		checker := NewBootConfigParamChecker(testCase.params...)
-		checker.kernelVersionReader = testCase.kernelVersionReader
-		checker.bootConfigReader = testCase.bootConfigReader
+		checker := &bootConfigParamChecker{
+			Params:              testCase.params,
+			kernelVersionReader: testCase.kernelVersionReader,
+			bootConfigReader:    testCase.bootConfigReader,
+		}
 		var reporter health.Probes
 		checker.Check(context.TODO(), &reporter)
 		c.Assert(reporter, test.DeepCompare, testCase.probes, Commentf(testCase.comment))

--- a/monitoring/cgroup.go
+++ b/monitoring/cgroup.go
@@ -31,29 +31,29 @@ import (
 // NewCGroupChecker creates a new checker to verify existence
 // of cgroup mounts given with cgroups.
 // The checker should be executed in the host mount namespace.
-func NewCGroupChecker(cgroups ...string) CGroupChecker {
-	return CGroupChecker{
+func NewCGroupChecker(cgroups ...string) health.Checker {
+	return cgroupChecker{
 		cgroups:   cgroups,
 		getMounts: listProcMounts,
 	}
 }
 
-// CGroupChecker is a checker that verifies existence
+// cgroupChecker is a checker that verifies existence
 // of a set of cgroup mounts
-type CGroupChecker struct {
+type cgroupChecker struct {
 	cgroups   []string
 	getMounts mountGetterFunc
 }
 
 // Name returns name of the checker
 // Implements health.Checker
-func (r CGroupChecker) Name() string {
+func (r cgroupChecker) Name() string {
 	return cgroupCheckerID
 }
 
 // Check verifies existence of cgroup mounts given in r.cgroups.
 // Implements health.Checker
-func (r CGroupChecker) Check(ctx context.Context, reporter health.Reporter) {
+func (r cgroupChecker) Check(ctx context.Context, reporter health.Reporter) {
 	mounts, err := r.getMounts()
 	if err != nil {
 		reporter.Add(NewProbeFromErr(r.Name(), "", trace.Wrap(err)))

--- a/monitoring/cgroup_test.go
+++ b/monitoring/cgroup_test.go
@@ -70,8 +70,10 @@ func (*MonitoringSuite) TestValidatesCGroupMounts(c *C) {
 
 	// exercise / verify
 	for _, testCase := range testCases {
-		checker := NewCGroupChecker(testCase.cgroups...)
-		checker.getMounts = mountsReader(testCgroups)
+		checker := cgroupChecker{
+			cgroups:   testCase.cgroups,
+			getMounts: mountsReader(testCgroups),
+		}
 		var reporter health.Probes
 		checker.Check(context.TODO(), &reporter)
 		c.Assert(reporter, test.DeepCompare, testCase.probes, Commentf(testCase.comment))

--- a/monitoring/fs_linux.go
+++ b/monitoring/fs_linux.go
@@ -37,7 +37,7 @@ import (
 // The checker is not meant to be run periodically but once before the Docker has been set up.
 //
 // See https://github.com/moby/moby/blob/v1.13.0-rc4/docs/deprecated.md#backing-filesystem-without-d_type-support-for-overlayoverlay2
-func NewDTypeChecker(path string) dtypeChecker {
+func NewDTypeChecker(path string) health.Checker {
 	return dtypeChecker(path)
 }
 
@@ -57,8 +57,9 @@ func (r dtypeChecker) Check(ctx context.Context, reporter health.Reporter) {
 	if !supports {
 		reporter.Add(&pb.Probe{
 			Checker: r.Name(),
-			Detail:  fmt.Sprintf("filesystem on %v does not support d_type. The overlay and overlay2 Docker storage drivers do not work as expected if the backing filesystem does not support d_type", string(r)),
-			Status:  pb.Probe_Failed,
+			Detail: fmt.Sprintf("filesystem on %v does not support d_type, "+
+				"see https://www.gravitational.com/docs/faq/#d_type-support-in-filesystem", string(r)),
+			Status: pb.Probe_Failed,
 		})
 	} else {
 		reporter.Add(&pb.Probe{Checker: r.Name(), Status: pb.Probe_Running})

--- a/monitoring/modules.go
+++ b/monitoring/modules.go
@@ -31,20 +31,20 @@ import (
 )
 
 // NewKernelModuleChecker creates a new kernel module checker
-func NewKernelModuleChecker(names ...string) KernelModuleChecker {
-	return KernelModuleChecker{
+func NewKernelModuleChecker(names ...string) health.Checker {
+	return kernelModuleChecker{
 		Modules:    names,
 		getModules: ReadModules,
 	}
 }
 
 // Name returns name of the checker
-func (r KernelModuleChecker) Name() string {
+func (r kernelModuleChecker) Name() string {
 	return kernelModuleCheckerID
 }
 
 // Check determines if the modules specified with r.Modules have been loaded
-func (r KernelModuleChecker) Check(ctx context.Context, reporter health.Reporter) {
+func (r kernelModuleChecker) Check(ctx context.Context, reporter health.Reporter) {
 	err := r.check(ctx, reporter)
 	if err != nil {
 		reporter.Add(NewProbeFromErr(r.Name(), "", trace.Wrap(err)))
@@ -53,7 +53,7 @@ func (r KernelModuleChecker) Check(ctx context.Context, reporter health.Reporter
 	reporter.Add(&pb.Probe{Checker: r.Name(), Status: pb.Probe_Running})
 }
 
-func (r KernelModuleChecker) check(ctx context.Context, reporter health.Reporter) error {
+func (r kernelModuleChecker) check(ctx context.Context, reporter health.Reporter) error {
 	modules, err := r.getModules()
 	if err != nil {
 		return trace.Wrap(err)
@@ -72,8 +72,8 @@ func (r KernelModuleChecker) check(ctx context.Context, reporter health.Reporter
 	return trace.NewAggregate(errors...)
 }
 
-// KernelModuleChecker checks if the specified set of kernel modules are loaded
-type KernelModuleChecker struct {
+// kernelModuleChecker checks if the specified set of kernel modules are loaded
+type kernelModuleChecker struct {
 	// Modules lists required kernel modules
 	Modules    []string
 	getModules moduleGetterFunc

--- a/monitoring/modules_test.go
+++ b/monitoring/modules_test.go
@@ -119,8 +119,10 @@ func (_ *MonitoringSuite) TestVerifiesModules(c *C) {
 
 	// exercise / verify
 	for _, testCase := range testCases {
-		checker := NewKernelModuleChecker(testCase.modules...)
-		checker.getModules = moduleReader(modulesData)
+		checker := kernelModuleChecker{
+			Modules:    testCase.modules,
+			getModules: moduleReader(modulesData),
+		}
 		var reporter health.Probes
 		checker.Check(context.TODO(), &reporter)
 		c.Assert(reporter, test.DeepCompare, testCase.probes, Commentf(testCase.comment))

--- a/monitoring/os_linux.go
+++ b/monitoring/os_linux.go
@@ -47,28 +47,28 @@ import (
 // NewOSChecker(OSRelease{Name: "Ubuntu", VersionID: "16"})
 //
 // will match all 16.x ubuntu distribution releases.
-func NewOSChecker(releases ...OSRelease) *OSChecker {
-	return &OSChecker{
+func NewOSChecker(releases ...OSRelease) health.Checker {
+	return &osReleaseChecker{
 		Releases:   releases,
 		getRelease: getRealOSRelease,
 	}
 }
 
-// OSChecker validates host OS based on
+// osReleaseChecker validates host OS based on
 // https://www.freedesktop.org/software/systemd/man/os-release.html
-type OSChecker struct {
+type osReleaseChecker struct {
 	// Releases lists all supported releases
 	Releases   []OSRelease
 	getRelease osReleaseGetter
 }
 
 // Name returns name of the checker
-func (c *OSChecker) Name() string {
+func (c *osReleaseChecker) Name() string {
 	return osCheckerID
 }
 
 // Check checks current OS and release is within supported list
-func (c *OSChecker) Check(ctx context.Context, reporter health.Reporter) {
+func (c *osReleaseChecker) Check(ctx context.Context, reporter health.Reporter) {
 	info, err := c.getRelease()
 	if err != nil {
 		reporter.Add(NewProbeFromErr(osCheckerID,

--- a/monitoring/os_linux_test.go
+++ b/monitoring/os_linux_test.go
@@ -65,8 +65,10 @@ func (*MonitoringSuite) TestValidatesOS(c *C) {
 
 	// exercise / verify
 	for _, testCase := range testCases {
-		checker := NewOSChecker(testCase.releases...)
-		checker.getRelease = testCase.getRelease
+		checker := &osReleaseChecker{
+			Releases:   testCase.releases,
+			getRelease: testCase.getRelease,
+		}
 		var reporter health.Probes
 		checker.Check(context.TODO(), &reporter)
 		c.Assert(reporter, test.DeepCompare, testCase.probes, Commentf(testCase.comment))

--- a/monitoring/storage_test.go
+++ b/monitoring/storage_test.go
@@ -47,46 +47,58 @@ func (_ *StorageSuite) TestStorage(c *C) {
 
 	c.Logf("%+v", tmp)
 
-	NewStorageChecker(StorageChecker{
-		Path:        "/tmp",
+	storageChecker{
+		StorageConfig: StorageConfig{
+			Path: "/tmp",
+		},
 		osInterface: testOS{mountList: mounts},
-	}).probe(c, "no conditions", shallSucceed)
+	}.probe(c, "no conditions", shallSucceed)
 
-	StorageChecker{
-		Path:              path.Join("/tmp", "does-not-exist"),
-		WillBeCreated:     true,
-		Filesystems:       []string{tmp.SysTypeName},
-		MinFreeBytes:      uint64(1024),
-		MinBytesPerSecond: uint64(1024),
-		osInterface:       testOS{mountList: mounts, bytesPerSecond: 512, bytesAvail: 512},
+	storageChecker{
+		StorageConfig: StorageConfig{
+			Path:              path.Join("/tmp", "does-not-exist"),
+			WillBeCreated:     true,
+			Filesystems:       []string{tmp.SysTypeName},
+			MinFreeBytes:      uint64(1024),
+			MinBytesPerSecond: uint64(1024),
+		},
+		osInterface: testOS{mountList: mounts, bytesPerSecond: 512, bytesAvail: 512},
 	}.probe(c, "unreasonable requirements", shallFail)
 
-	StorageChecker{
-		Path:              path.Join("/tmp", "does-not-exist"),
-		WillBeCreated:     true,
-		Filesystems:       []string{tmp.SysTypeName},
-		MinFreeBytes:      uint64(1024),
-		MinBytesPerSecond: uint64(1024),
-		osInterface:       testOS{mountList: mounts, bytesPerSecond: 2048, bytesAvail: 2048},
+	storageChecker{
+		StorageConfig: StorageConfig{
+			Path:              path.Join("/tmp", "does-not-exist"),
+			WillBeCreated:     true,
+			Filesystems:       []string{tmp.SysTypeName},
+			MinFreeBytes:      uint64(1024),
+			MinBytesPerSecond: uint64(1024),
+		},
+		osInterface: testOS{mountList: mounts, bytesPerSecond: 2048, bytesAvail: 2048},
 	}.probe(c, "reasonable requirements", shallSucceed)
 
-	StorageChecker{
-		Path:          path.Join("/tmp", fmt.Sprintf("%d", time.Now().Unix())),
-		WillBeCreated: true,
-		Filesystems:   []string{"no-such-fs"},
-		osInterface:   testOS{mountList: mounts},
+	storageChecker{
+		StorageConfig: StorageConfig{
+			Path:          path.Join("/tmp", fmt.Sprintf("%d", time.Now().Unix())),
+			WillBeCreated: true,
+			Filesystems:   []string{"no-such-fs"},
+		},
+		osInterface: testOS{mountList: mounts},
 	}.probe(c, "fs type mismatch", shallFail)
 
-	StorageChecker{
-		Path:          path.Join("/tmp", fmt.Sprintf("%d", time.Now().Unix())),
-		WillBeCreated: false,
-		osInterface:   testOS{mountList: mounts},
+	storageChecker{
+		StorageConfig: StorageConfig{
+			Path:          path.Join("/tmp", fmt.Sprintf("%d", time.Now().Unix())),
+			WillBeCreated: false,
+		},
+		osInterface: testOS{mountList: mounts},
 	}.probe(c, "missing folder", shallFail)
 
-	StorageChecker{
-		Path:          path.Join("/tmp", fmt.Sprintf("%d", time.Now().Unix())),
-		WillBeCreated: true,
-		osInterface:   testOS{mountList: mounts},
+	storageChecker{
+		StorageConfig: StorageConfig{
+			Path:          path.Join("/tmp", fmt.Sprintf("%d", time.Now().Unix())),
+			WillBeCreated: true,
+		},
+		osInterface: testOS{mountList: mounts},
 	}.probe(c, "create if missing", shallSucceed)
 }
 
@@ -97,15 +109,17 @@ func (_ *StorageSuite) TestMatchesFilesystem(c *C) {
 		sigar.FileSystem{DevName: "sysfs", DirName: "/sys", SysTypeName: "sysfs", Options: "rw,seclabel,nosuid,nodev,noexec,relatime"},
 	}
 
-	StorageChecker{
-		Path:          "/var/lib/data",
-		WillBeCreated: true,
-		Filesystems:   []string{"xfs", "ext4"},
-		osInterface:   testOS{mountList: mounts},
+	storageChecker{
+		StorageConfig: StorageConfig{
+			Path:          "/var/lib/data",
+			WillBeCreated: true,
+			Filesystems:   []string{"xfs", "ext4"},
+		},
+		osInterface: testOS{mountList: mounts},
 	}.probe(c, "discards rootfs", shallSucceed)
 }
 
-func (ch StorageChecker) probe(c *C, msg string, success bool) {
+func (ch storageChecker) probe(c *C, msg string, success bool) {
 	var probes health.Probes
 
 	ch.Check(context.TODO(), &probes)

--- a/monitoring/systemd.go
+++ b/monitoring/systemd.go
@@ -28,53 +28,34 @@ import (
 	"github.com/coreos/go-systemd/dbus"
 )
 
-type loadState string
-
-const (
-	loadStateLoaded   loadState = "loaded"
-	loadStateError              = "error"
-	loadStateMasked             = "masked"
-	loadStateNotFound           = "not-found"
-)
-
-type activeState string
-
-const (
-	activeStateActive       activeState = "active"
-	activeStateReloading                = "reloading"
-	activeStateInactive                 = "inactive"
-	activeStateFailed                   = "failed"
-	activeStateActivating               = "activating"
-	activeStateDeactivating             = "deactivating"
-)
-
+// NewSystemdChecker returns a new checker that reports status
+// of systemd units
 func NewSystemdChecker() systemdChecker {
 	return systemdChecker{}
 }
 
-// SystemChecker is a health checker for services managed by systemd/monit.
-type systemdChecker struct{}
-
-type serviceStatus struct {
-	name   string
-	status pb.Probe_Type
-	err    error
-}
-
-var systemStatusCmd = []string{"/bin/systemctl", "is-system-running"}
-
+// SystemStatusType describes the unit status
 type SystemStatusType string
 
 const (
-	SystemStatusRunning  SystemStatusType = "running"
-	SystemStatusDegraded                  = "degraded"
-	SystemStatusLoading                   = "loading"
-	SystemStatusStopped                   = "stopped"
-	SystemStatusUnknown                   = ""
+	// SystemStatusRunning is the status of an active unit
+	SystemStatusRunning SystemStatusType = "running"
+	// SystemStatusDegraded is the status of a failed unit
+	SystemStatusDegraded = "degraded"
+	// SystemStatusLoading indicates the unit in initializing or starting state
+	SystemStatusLoading = "loading"
+	// SystemStatusStopped indicates that the unit is stopped
+	SystemStatusStopped = "stopped"
+	// SystemStatusUnknown is the value of the unit state when it is unknown
+	SystemStatusUnknown = ""
 )
 
+// Name returns the name of this checker.
+// Implements health.Checker
 func (r systemdChecker) Name() string { return "systemd" }
 
+// Check evaluates the status of systemd.
+// Implements health.Checker
 func (r systemdChecker) Check(ctx context.Context, reporter health.Reporter) {
 	systemStatus, err := isSystemRunning()
 	if err != nil {
@@ -156,3 +137,34 @@ func isExitError(err error) bool {
 	}
 	return false
 }
+
+// SystemChecker is a health checker for services managed by systemd/monit.
+type systemdChecker struct{}
+
+type serviceStatus struct {
+	name   string
+	status pb.Probe_Type
+	err    error
+}
+
+var systemStatusCmd = []string{"/bin/systemctl", "is-system-running"}
+
+type loadState string
+
+const (
+	loadStateLoaded   loadState = "loaded"
+	loadStateError              = "error"
+	loadStateMasked             = "masked"
+	loadStateNotFound           = "not-found"
+)
+
+type activeState string
+
+const (
+	activeStateActive       activeState = "active"
+	activeStateReloading                = "reloading"
+	activeStateInactive                 = "inactive"
+	activeStateFailed                   = "failed"
+	activeStateActivating               = "activating"
+	activeStateDeactivating             = "deactivating"
+)


### PR DESCRIPTION
This will avoid mistakes when checkers are initialized directly and panic when used.