### PR TITLE
Update kernel module checker to validate modules with alternative names

### DIFF
--- a/agent/server_test.go
+++ b/agent/server_test.go
@@ -462,6 +462,7 @@ func (r *AgentSuite) TestFailsIfTimesOutToCollectStatus(c *C) {
 			Probes: []*pb.Probe{healthyProbe},
 		},
 	}
+	summary := fmt.Sprintf(msgNoStatus, "node,")
 	// The agent might receive status about the failed node but in state "unknown"
 	if len(resp.Status.Nodes) == 2 {
 		expected = append(expected, &pb.NodeStatus{
@@ -470,12 +471,14 @@ func (r *AgentSuite) TestFailsIfTimesOutToCollectStatus(c *C) {
 			MemberStatus: &pb.MemberStatus{Name: "master", Addr: "<nil>:0",
 				Tags: tags{"role": string(RoleMaster)}, Status: pb.MemberStatus_Failed},
 		})
+		// Summary is empty with statuses from both nodes
+		summary = ""
 	}
 	c.Assert(resp.Status, test.DeepCompare, &pb.SystemStatus{
 		Status:    pb.SystemStatus_Degraded,
 		Nodes:     expected,
 		Timestamp: pb.NewTimeToProto(clock.Now()),
-		Summary:   fmt.Sprintf(msgNoStatus, "node,"),
+		Summary:   summary,
 	})
 }
 

--- a/monitoring/modules.go
+++ b/monitoring/modules.go
@@ -68,7 +68,7 @@ func (r kernelModuleChecker) check(ctx context.Context, reporter health.Reporter
 	}
 
 	for _, module := range r.Modules {
-		if !modules.WasLoaded(module) {
+		if !modules.IsLoaded(module) {
 			reporter.Add(&pb.Probe{
 				Checker: r.Name(),
 				Detail:  fmt.Sprintf("%v not loaded", module),
@@ -124,8 +124,8 @@ func ReadModulesFrom(r io.Reader) (modules Modules, err error) {
 	return modules, nil
 }
 
-// WasLoaded determines whether module name is loaded.
-func (r Modules) WasLoaded(module ModuleRequest) bool {
+// IsLoaded determines whether module name is loaded.
+func (r Modules) IsLoaded(module ModuleRequest) bool {
 	_, loaded := r[module.Name]
 	if loaded {
 		return true

--- a/monitoring/modules.go
+++ b/monitoring/modules.go
@@ -32,9 +32,9 @@ import (
 )
 
 // NewKernelModuleChecker creates a new kernel module checker
-func NewKernelModuleChecker(names ...string) health.Checker {
+func NewKernelModuleChecker(modules ...ModuleRequest) health.Checker {
 	return kernelModuleChecker{
-		Modules:    names,
+		Modules:    modules,
 		getModules: ReadModules,
 	}
 }
@@ -71,7 +71,7 @@ func (r kernelModuleChecker) check(ctx context.Context, reporter health.Reporter
 		if !modules.WasLoaded(module) {
 			reporter.Add(&pb.Probe{
 				Checker: r.Name(),
-				Detail:  fmt.Sprintf("kernel module %q not loaded", module),
+				Detail:  fmt.Sprintf("%v not loaded", module),
 				Status:  pb.Probe_Failed,
 			})
 		}
@@ -83,7 +83,7 @@ func (r kernelModuleChecker) check(ctx context.Context, reporter health.Reporter
 // kernelModuleChecker checks if the specified set of kernel modules are loaded
 type kernelModuleChecker struct {
 	// Modules lists required kernel modules
-	Modules    []string
+	Modules    []ModuleRequest
 	getModules moduleGetterFunc
 }
 
@@ -125,9 +125,36 @@ func ReadModulesFrom(r io.Reader) (modules Modules, err error) {
 }
 
 // WasLoaded determines whether module name is loaded.
-func (r Modules) WasLoaded(name string) bool {
-	_, loaded := r[name]
-	return loaded
+func (r Modules) WasLoaded(module ModuleRequest) bool {
+	_, loaded := r[module.Name]
+	if loaded {
+		return true
+	}
+	// Check alternative module names
+	for _, name := range module.Names {
+		if _, loaded = r[name]; loaded {
+			return true
+		}
+	}
+	return false
+}
+
+// String returns a text representation of this kernel module request
+func (r ModuleRequest) String() string {
+	if len(r.Names) == 0 {
+		return fmt.Sprintf("kernel module %q", r.Name)
+	}
+	return fmt.Sprintf("kernel module %q (%q)", r.Name, r.Names)
+}
+
+// ModuleRequest describes a kernel module
+type ModuleRequest struct {
+	// Name names the kernel module
+	Name string
+	// Names lists alternative names for the module if any.
+	// For example, on CentOS 7.2 bridge netfilter module is called "bridge"
+	// instead of "br_netfilter".
+	Names []string
 }
 
 // Modules lists kernel modules
@@ -136,6 +163,11 @@ type Modules map[string]Module
 // IsLoaded determines if this module is loaded
 func (r Module) IsLoaded() bool {
 	return r.ModuleState == ModuleStateLive
+}
+
+// String returns a text representation of this kernel module
+func (r Module) String() string {
+	return fmt.Sprintf("kernel module %q", r.Name)
 }
 
 // Module describes a kernel module

--- a/monitoring/modules_test.go
+++ b/monitoring/modules_test.go
@@ -90,7 +90,7 @@ func (_ *MonitoringSuite) TestHasModules(c *C) {
 	// verify
 	c.Assert(err, IsNil)
 	for _, module := range modules("ebtables", "br_netfilter") {
-		c.Assert(kernelModules.WasLoaded(module), Equals, true)
+		c.Assert(kernelModules.IsLoaded(module), Equals, true)
 	}
 }
 

--- a/monitoring/modules_test.go
+++ b/monitoring/modules_test.go
@@ -44,6 +44,7 @@ func (_ *MonitoringSuite) TestLoadsModules(c *C) {
 			modules: moduleMap(
 				Module{Name: "br_netfilter", ModuleState: ModuleStateLive},
 				Module{Name: "nf_conntrack_netlink", ModuleState: ModuleStateLive},
+				Module{Name: "alternative_required", ModuleState: ModuleStateLive},
 				Module{Name: "ebtable_filter", ModuleState: ModuleStateLive, Instances: 1},
 				Module{Name: "ebtables", ModuleState: ModuleStateLive, Instances: 3},
 				Module{Name: "nfsd", ModuleState: ModuleStateLive, Instances: 1},
@@ -84,30 +85,30 @@ func (_ *MonitoringSuite) TestLoadsModules(c *C) {
 
 func (_ *MonitoringSuite) TestHasModules(c *C) {
 	// exercise
-	modules, err := ReadModulesFrom(bytes.NewReader(modulesData))
+	kernelModules, err := ReadModulesFrom(bytes.NewReader(modulesData))
 
 	// verify
 	c.Assert(err, IsNil)
-	for _, module := range []string{"ebtables", "br_netfilter"} {
-		c.Assert(modules.WasLoaded(module), Equals, true)
+	for _, module := range modules("ebtables", "br_netfilter") {
+		c.Assert(kernelModules.WasLoaded(module), Equals, true)
 	}
 }
 
 func (_ *MonitoringSuite) TestValidatesModules(c *C) {
 	var testCases = []struct {
-		modules []string
+		modules []ModuleRequest
 		reader  moduleGetterFunc
 		probes  health.Probes
 		comment string
 	}{
 		{
-			modules: []string{"ebtables", "br_netfilter"},
+			modules: modules("ebtables", "br_netfilter"),
 			reader:  moduleReader(modulesData),
 			probes:  health.Probes{&pb.Probe{Checker: kernelModuleCheckerID, Status: pb.Probe_Running}},
 			comment: "running",
 		},
 		{
-			modules: []string{"required"},
+			modules: modules("required"),
 			reader:  moduleReader(modulesData),
 			probes: health.Probes{
 				&pb.Probe{
@@ -130,7 +131,7 @@ func (_ *MonitoringSuite) TestValidatesModules(c *C) {
 			comment: "skip test for empty requirements",
 		},
 		{
-			modules: []string{"required"},
+			modules: modules("required"),
 			reader:  testFailingModuleReader(trace.NotFound("file or directory not found")),
 			probes: health.Probes{
 				&pb.Probe{
@@ -141,7 +142,7 @@ func (_ *MonitoringSuite) TestValidatesModules(c *C) {
 			comment: "skip test if no modules file available",
 		},
 		{
-			modules: []string{"required"},
+			modules: modules("required"),
 			reader:  testFailingModuleReader(trace.AccessDenied("permission denied")),
 			probes: health.Probes{
 				&pb.Probe{
@@ -152,6 +153,22 @@ func (_ *MonitoringSuite) TestValidatesModules(c *C) {
 				},
 			},
 			comment: "fail if error prevents from reading the file (other than not found)",
+		},
+		{
+			modules: []ModuleRequest{
+				{
+					Name:  "required",
+					Names: []string{"alternative_required"},
+				},
+			},
+			reader: moduleReader(modulesData),
+			probes: health.Probes{
+				&pb.Probe{
+					Checker: kernelModuleCheckerID,
+					Status:  pb.Probe_Running,
+				},
+			},
+			comment: "successful match based on alternative module name",
 		},
 	}
 
@@ -187,8 +204,17 @@ func moduleMap(modules ...Module) Modules {
 	return result
 }
 
+func modules(names ...string) (result []ModuleRequest) {
+	result = make([]ModuleRequest, 0, len(names))
+	for _, name := range names {
+		result = append(result, ModuleRequest{Name: name})
+	}
+	return result
+}
+
 var modulesData = []byte(`br_netfilter 22209 0 - Live 0xffffffffc063f000
 nf_conntrack_netlink 40449 0 - Live 0xffffffffc0659000
+alternative_required 1 0 - Live 0xffffffffb123a019
 ebtable_filter 12827 1 - Live 0xffffffffc0415000
 ebtables 35009 3 ebtable_nat,ebtable_broute,ebtable_filter, Live 0xffffffffc0407000
 nfsd 342857 1 - Live 0xffffffffc033f000


### PR DESCRIPTION
Update kernel module checker to validate kernel modules with alternative names (for example, bridge netfilter which is called either `br-netfilter` or `bridge` depending on the distribution).

Fixes https://github.com/gravitational/gravity/issues/3303.