### PR TITLE
Use TLS1.2 on port 7575

### DIFF
--- a/agent/client.go
+++ b/agent/client.go
@@ -17,6 +17,10 @@ limitations under the License.
 package agent
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
 
 	"github.com/gravitational/trace"
@@ -41,10 +45,31 @@ type client struct {
 // NewClient creates a agent RPC client to the given address
 // using the specified client certificate certFile
 func NewClient(addr, certFile string) (*client, error) {
-	creds, err := credentials.NewClientTLSFromFile(certFile, "")
+	cert, err := ioutil.ReadFile(certFile)
 	if err != nil {
-		return nil, trace.Wrap(err, "failed to read certificate")
+		return nil, trace.ConvertSystemError(err)
 	}
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM(cert) {
+		return nil, trace.Wrap(err, "failed to append certificates from %v", certFile)
+	}
+
+	creds := credentials.NewTLS(&tls.Config{
+		RootCAs:    certPool,
+		MinVersion: tls.VersionTLS12,
+		// Use TLS Modern capability suites
+		// https://wiki.mozilla.org/Security/Server_Side_TLS
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		},
+	})
 
 	return NewClientWithCreds(addr, creds)
 }

--- a/agent/server.go
+++ b/agent/server.go
@@ -72,10 +72,13 @@ func (r *server) LocalStatus(ctx context.Context, req *pb.LocalStatusRequest) (r
 
 // newRPCServer creates an agent RPC endpoint for each provided listener.
 func newRPCServer(agent *agent, caFile, certFile, keyFile string, rpcAddrs []string) (*server, error) {
-	creds, err := credentials.NewServerTLSFromFile(certFile, keyFile)
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to read certificate/key from %v/%v", certFile, keyFile)
 	}
+	creds := credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12})
 
 	healthzHandler, err := newHealthHandler(caFile)
 	if err != nil {

--- a/agent/server.go
+++ b/agent/server.go
@@ -76,9 +76,23 @@ func newRPCServer(agent *agent, caFile, certFile, keyFile string, rpcAddrs []str
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to read certificate/key from %v/%v", certFile, keyFile)
 	}
+
 	creds := credentials.NewTLS(&tls.Config{
 		Certificates: []tls.Certificate{cert},
-		MinVersion:   tls.VersionTLS12})
+		MinVersion:   tls.VersionTLS12,
+		// Use TLS Modern capability suites
+		// https://wiki.mozilla.org/Security/Server_Side_TLS
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		},
+	})
 
 	healthzHandler, err := newHealthHandler(caFile)
 	if err != nil {
@@ -94,6 +108,18 @@ func newRPCServer(agent *agent, caFile, certFile, keyFile string, rpcAddrs []str
 
 	tlsConfig := &tls.Config{
 		MinVersion: tls.VersionTLS12,
+		// Use TLS Modern capability suites
+		// https://wiki.mozilla.org/Security/Server_Side_TLS
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		},
 	}
 	for _, addr := range rpcAddrs {
 		srv := &http.Server{


### PR DESCRIPTION
Result:
```
[root@sergei-dev-2 ~]# nmap --script +ssl-enum-ciphers -p 7575 10.162.0.14

Starting Nmap 6.40 ( http://nmap.org ) at 2018-06-14 18:28 UTC
Nmap scan report for sergei-dev-2.c.kubeadm-167321.internal (10.162.0.14)
Host is up (0.000088s latency).
PORT     STATE SERVICE
7575/tcp open  unknown
| ssl-enum-ciphers: 
|   TLSv1.2: 
|     ciphers: 
|       TLS_RSA_WITH_3DES_EDE_CBC_SHA - strong
|       TLS_RSA_WITH_AES_128_CBC_SHA - strong
|       TLS_RSA_WITH_AES_128_GCM_SHA256 - strong
|       TLS_RSA_WITH_AES_256_CBC_SHA - strong
|       TLS_RSA_WITH_AES_256_GCM_SHA384 - strong
|     compressors: 
|       NULL
|_  least strength: strong

Nmap done: 1 IP address (1 host up) scanned in 0.41 seconds
```