### PR TITLE
Fix port checker.

### DIFF
--- a/monitoring/port.go
+++ b/monitoring/port.go
@@ -107,8 +107,8 @@ func (c *portChecker) checkProcess(proc process, reporter health.Reporter) bool 
 		// ignore sockets in time-wait and closed states since they're going
 		// away soon
 		switch proc.socket.state() {
-		case TimeWait, Close:
-			log.Debugf("Ignoring socket in %q state for program %q(pid=%v).", proc.socket.state(), proc.name, proc.pid)
+		case TimeWait:
+			log.Debugf("Ignoring %v for program %q(pid=%v).", formatSocket(proc.socket), proc.name, proc.pid)
 			continue
 		}
 		if uint64(proc.localAddr().port) >= r.From && uint64(proc.localAddr().port) <= r.To {

--- a/monitoring/procfs_net.go
+++ b/monitoring/procfs_net.go
@@ -399,6 +399,17 @@ type addr struct {
 	port int
 }
 
+// String returns the address' string representation
+func (a addr) String() string {
+	return fmt.Sprintf("%s:%v", a.ip, a.port)
+}
+
+// formatSocket formats the provided socket to a string
+func formatSocket(s socket) string {
+	return fmt.Sprintf("socket(proto=%v, addr=%s, state=%s, inode=%v)",
+		s.proto(), s.localAddr(), s.state(), s.inode())
+}
+
 // procNet* are standard paths to Linux procfs information on sockets
 const (
 	procNetTCP  = "/proc/net/tcp"


### PR DESCRIPTION
For some reason all udp sockets get "close" state so with yesterday's fix they are always skipped. Should only filter out time-wait sockets.
