### PR TITLE
use mTLS for client authentication

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -128,14 +128,11 @@ func New(config *Config) (Agent, error) {
 		serfClient:      client,
 		name:            config.Name,
 		cache:           config.Cache,
+		dialRPC:         defaultDialRPC(config.CAFile, config.CertFile, config.KeyFile),
 		statusClock:     clock,
 		recycleClock:    clock,
 		localStatus:     emptyNodeStatus(config.Name),
 		metricsListener: metricsListener,
-		caFile:          config.CAFile,
-		certFile:        config.CertFile,
-		keyFile:         config.KeyFile,
-		rpcPort:         RPCPort,
 	}
 
 	agent.rpc, err = newRPCServer(agent, config.CAFile, config.CertFile, config.KeyFile, config.RPCAddrs)
@@ -188,11 +185,12 @@ type agent struct {
 	// status sync with other agents.
 	rpc RPCServer
 
-	// rpcPort is the por this server is listening on for RPC calls
-	rpcPort int
-
 	// cache persists node status history.
 	cache cache.Cache
+
+	// dialRPC is a factory function to create clients to other agents.
+	// If future, agent address discovery will happen through serf.
+	dialRPC dialRPC
 
 	// done is a channel used for cleanup.
 	done chan struct{}
@@ -210,13 +208,9 @@ type agent struct {
 	// from remote nodes during status collection.
 	// Defaults to statusQueryReplyTimeout if unspecified
 	statusQueryReplyTimeout time.Duration
-
-	// TLS certificate/key files for connecting to other agents
-	// using mTLS
-	caFile   string
-	certFile string
-	keyFile  string
 }
+
+type dialRPC func(*serf.Member) (*client, error)
 
 // Start starts the agent's background tasks.
 func (r *agent) Start() error {
@@ -299,11 +293,6 @@ func (r *agent) Close() (err error) {
 // LocalStatus reports the status of the local agent node.
 func (r *agent) LocalStatus() *pb.NodeStatus {
 	return r.recentLocalStatus()
-}
-
-func (r *agent) dialMember(member *serf.Member) (*client, error) {
-	addr := fmt.Sprintf("%s:%d", member.Addr.String(), r.rpcPort)
-	return NewClient(addr, r.caFile, r.certFile, r.keyFile)
 }
 
 // runChecks executes the monitoring tests configured for this agent in parallel.
@@ -507,7 +496,7 @@ func (r *agent) getLocalStatus(ctx context.Context, local serf.Member, respc cha
 
 // getStatusFrom obtains node status from the node identified by member.
 func (r *agent) getStatusFrom(ctx context.Context, member serf.Member, respc chan<- *statusResponse) {
-	client, err := r.dialMember(&member)
+	client, err := r.dialRPC(&member)
 	resp := &statusResponse{member: member}
 	if err != nil {
 		resp.err = trace.Wrap(err)

--- a/agent/client.go
+++ b/agent/client.go
@@ -44,19 +44,28 @@ type client struct {
 
 // NewClient creates a agent RPC client to the given address
 // using the specified client certificate certFile
-func NewClient(addr, certFile string) (*client, error) {
-	cert, err := ioutil.ReadFile(certFile)
+func NewClient(addr, caFile, certFile, keyFile string) (*client, error) {
+	// Load client cert/key
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		return nil, trace.ConvertSystemError(err)
+		return nil, trace.Wrap(err)
 	}
+
+	// Load the CA of the server
+	clientCACert, err := ioutil.ReadFile(caFile)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	certPool := x509.NewCertPool()
-	if !certPool.AppendCertsFromPEM(cert) {
-		return nil, trace.Wrap(err, "failed to append certificates from %v", certFile)
+	if !certPool.AppendCertsFromPEM(clientCACert) {
+		return nil, trace.Wrap(err, "failed to append certificates from %v", caFile)
 	}
 
 	creds := credentials.NewTLS(&tls.Config{
-		RootCAs:    certPool,
-		MinVersion: tls.VersionTLS12,
+		RootCAs:      certPool,
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
 		// Use TLS Modern capability suites
 		// https://wiki.mozilla.org/Security/Server_Side_TLS
 		CipherSuites: []uint16{

--- a/agent/client.go
+++ b/agent/client.go
@@ -54,7 +54,7 @@ func newClient(addr, serverName, caFile, certFile, keyFile string) (*client, err
 	// Load client cert/key
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.ConvertSystemError(err)
 	}
 
 	// Load the CA of the server

--- a/agent/client.go
+++ b/agent/client.go
@@ -45,6 +45,12 @@ type client struct {
 // NewClient creates a agent RPC client to the given address
 // using the specified client certificate certFile
 func NewClient(addr, caFile, certFile, keyFile string) (*client, error) {
+	return newClient(addr, "", caFile, certFile, keyFile)
+}
+
+// newClient additional allows a serverName override, but is only available
+// from unit tests
+func newClient(addr, serverName, caFile, certFile, keyFile string) (*client, error) {
 	// Load client cert/key
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
@@ -54,7 +60,7 @@ func NewClient(addr, caFile, certFile, keyFile string) (*client, error) {
 	// Load the CA of the server
 	clientCACert, err := ioutil.ReadFile(caFile)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.ConvertSystemError(err)
 	}
 
 	certPool := x509.NewCertPool()
@@ -66,6 +72,7 @@ func NewClient(addr, caFile, certFile, keyFile string) (*client, error) {
 		RootCAs:      certPool,
 		Certificates: []tls.Certificate{cert},
 		MinVersion:   tls.VersionTLS12,
+		ServerName:   serverName,
 		// Use TLS Modern capability suites
 		// https://wiki.mozilla.org/Security/Server_Side_TLS
 		CipherSuites: []uint16{

--- a/agent/server.go
+++ b/agent/server.go
@@ -25,10 +25,10 @@ import (
 	"strings"
 
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
-	serf "github.com/hashicorp/serf/client"
 
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
+	serf "github.com/hashicorp/serf/client"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"

--- a/agent/server_test.go
+++ b/agent/server_test.go
@@ -539,28 +539,6 @@ func testDialRPC(port int, certFile, keyFile string) dialRPC {
 	return func(member *serf.Member) (*client, error) {
 		return newClient(fmt.Sprintf(":%d", port), "agent", certFile, certFile, keyFile)
 	}
-	/*return func(member *serf.Member) (*client, error) {
-		addr := fmt.Sprintf(":%d", port)
-
-		// Load client cert/key
-		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		creds, err := credentials.NewClientTLSFromFile(certFile, "agent")
-		if err != nil {
-			return nil, err
-		}
-
-
-
-		client, err := NewClientWithCreds(addr, creds)
-		if err != nil {
-			return nil, err
-		}
-		return client, err
-	}*/
 }
 
 func (r *AgentSuite) httpClient(url string) (*roundtrip.Client, error) {
@@ -745,7 +723,7 @@ func generateCert(certFile, keyFile string) error {
 		NotAfter:  time.Now().Add(1 * time.Hour),
 
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
 		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
 		DNSNames:              []string{"agent"},

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -79,7 +79,9 @@ func run() error {
 		cstatusRPCPort     = cstatus.Flag("rpc-port", "Local agent RPC port").Default("7575").Int()
 		cstatusPrettyPrint = cstatus.Flag("pretty", "Pretty-print the output").Bool()
 		cstatusLocal       = cstatus.Flag("local", "Query the status of the local node").Bool()
-		cstatusCertFile    = cstatus.Flag("cert-file", "Client SSL certificate file for RPC. This should be the CA certificate if the server certificates are signed by a CA").ExistingFile()
+		cstatusCAFile      = cstatus.Flag("ca-file", "CA certificate for verifying server certificates").ExistingFile()
+		cstatusCertFile    = cstatus.Flag("client-cert-file", "mTLS client certificate file").ExistingFile()
+		cstatusKeyFile     = cstatus.Flag("client-key-file", "mTLS client key file").ExistingFile()
 
 		// checks command
 		cchecks = app.Command("checks", "Run local compatibility checks")
@@ -159,7 +161,7 @@ func run() error {
 		}
 		err = runAgent(agentConfig, monitoringConfig, toAddrList(*cagentInitialCluster))
 	case cstatus.FullCommand():
-		_, err = status(*cstatusRPCPort, *cstatusLocal, *cstatusPrettyPrint, *cstatusCertFile)
+		_, err = status(*cstatusRPCPort, *cstatusLocal, *cstatusPrettyPrint, *cstatusCAFile, *cstatusCertFile, *cstatusKeyFile)
 	case cchecks.FullCommand():
 		err = localChecks()
 	case cversion.FullCommand():

--- a/cmd/agent/status.go
+++ b/cmd/agent/status.go
@@ -38,9 +38,9 @@ const statusTimeout = 5 * time.Second
 // the status of the cluster.
 // Returns true if the status query was successful, false - otherwise.
 // The output is prettified if prettyPrint is true.
-func status(RPCPort int, local, prettyPrint bool, certFile string) (ok bool, err error) {
+func status(RPCPort int, local, prettyPrint bool, caFile, certFile, keyFile string) (ok bool, err error) {
 	RPCAddr := fmt.Sprintf("127.0.0.1:%d", RPCPort)
-	client, err := agent.NewClient(RPCAddr, certFile)
+	client, err := agent.NewClient(RPCAddr, caFile, certFile, keyFile)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}

--- a/monitoring/modules_test.go
+++ b/monitoring/modules_test.go
@@ -112,9 +112,10 @@ func (_ *MonitoringSuite) TestValidatesModules(c *C) {
 			reader:  moduleReader(modulesData),
 			probes: health.Probes{
 				&pb.Probe{
-					Checker: KernelModuleCheckerID,
-					Detail:  `kernel module "required" not loaded`,
-					Status:  pb.Probe_Failed,
+					Checker:     KernelModuleCheckerID,
+					Detail:      `kernel module "required" not loaded`,
+					Status:      pb.Probe_Failed,
+					CheckerData: []byte("{\"Module\":{\"Name\":\"required\",\"Names\":null}}"),
 				},
 			},
 			comment: "missing module",


### PR DESCRIPTION
Setup satellite monitoring ports to use mTLS authentication.
https://github.com/gravitational/gravity.e/issues/3726

I did a bit of refactoring to support this as well:
- When receiving an HTTP request, avoid invoking the gRPC client to localhost, and instead just invoke the gRPC service directly in process.
- I think some of the tests are broken unrelated to this change, I fixed a couple but I think some tests are still broken.