### PR TITLE
Add a checker that tests if inotify is able to create watches

### DIFF
--- a/monitoring/defaults_linux.go
+++ b/monitoring/defaults_linux.go
@@ -79,7 +79,7 @@ func BasicCheckers(checkers ...health.Checker) health.Checker {
 			DefaultProcessChecker(),
 			DefaultPortChecker(),
 			DefaultBootConfigParams(),
-			NewINotifyChecker(),
+			NewInotifyChecker(),
 		},
 	}
 	c.checkers = append(c.checkers, checkers...)

--- a/monitoring/defaults_linux.go
+++ b/monitoring/defaults_linux.go
@@ -79,6 +79,7 @@ func BasicCheckers(checkers ...health.Checker) health.Checker {
 			DefaultProcessChecker(),
 			DefaultPortChecker(),
 			DefaultBootConfigParams(),
+			NewINotifyChecker(),
 		},
 	}
 	c.checkers = append(c.checkers, checkers...)

--- a/monitoring/defaults_linux_test.go
+++ b/monitoring/defaults_linux_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2016 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"context"
+
+	"github.com/gravitational/satellite/agent/health"
+	"gopkg.in/check.v1"
+)
+
+type InotifySuite struct{}
+
+func (_ *InotifySuite) TestCreateInotify(c *check.C) {
+	// Note, it's difficult to simulate on linux
+	// running out of inotify watches, so we only
+	// test the success case here.
+
+	checker := &iNotifyChecker{}
+	var probes health.Probes
+	checker.Check(context.TODO(), &probes)
+	c.Assert(probes.NumProbes(), check.Equals, 0)
+}

--- a/monitoring/inotify.go
+++ b/monitoring/inotify.go
@@ -1,0 +1,27 @@
+// +build !linux
+
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"github.com/gravitational/satellite/agent/health"
+)
+
+func NewINotifyChecker() health.Checker {
+	return noopChecker{}
+}

--- a/monitoring/inotify.go
+++ b/monitoring/inotify.go
@@ -22,9 +22,9 @@ import (
 	"github.com/gravitational/satellite/agent/health"
 )
 
-// NewINotifyChecker creates a new health.Checker that tests if inotify watches
+// NewInotifyChecker creates a new health.Checker that tests if inotify watches
 // can be created. This is usually an indication that the system has reached
 // fs.inotify.max_user_instances has been exhausted
-func NewINotifyChecker() health.Checker {
+func NewInotifyChecker() health.Checker {
 	return noopChecker{}
 }

--- a/monitoring/inotify.go
+++ b/monitoring/inotify.go
@@ -1,7 +1,7 @@
 // +build !linux
 
 /*
-Copyright 2017 Gravitational, Inc.
+Copyright 2018 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,6 +22,9 @@ import (
 	"github.com/gravitational/satellite/agent/health"
 )
 
+// NewINotifyChecker creates a new health.Checker that tests if inotify watches
+// can be created. This is usually an indication that the system has reached
+// fs.inotify.max_user_instances has been exhausted
 func NewINotifyChecker() health.Checker {
 	return noopChecker{}
 }

--- a/monitoring/inotify_linux.go
+++ b/monitoring/inotify_linux.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"context"
+
+	"github.com/gravitational/satellite/agent/health"
+	pb "github.com/gravitational/satellite/agent/proto/agentpb"
+
+	"golang.org/x/sys/unix"
+)
+
+func NewINotifyChecker() health.Checker {
+	return iNotifyChecker{}
+}
+
+// iNotifyChecker tries to create an inotify watch, and reports if it fails
+type iNotifyChecker struct {
+}
+
+// Name returns name of the checker
+func (c iNotifyChecker) Name() string {
+	return "inotify"
+}
+
+func (c iNotifyChecker) Check(ctx context.Context, reporter health.Reporter) {
+	fd, err := unix.InotifyInit()
+	if fd < 0 {
+		reporter.Add(&pb.Probe{
+			Checker: c.Name(),
+			Status:  pb.Probe_Failed,
+			Error:   "Unable to initialize inotify",
+		})
+	}
+	defer unix.Close(fd)
+
+	if _, err = unix.InotifyAddWatch(fd, "/", unix.IN_CREATE); err != nil {
+		reporter.Add(&pb.Probe{
+			Checker: c.Name(),
+			Status:  pb.Probe_Failed,
+			Error:   "Unable to create intofiy watch",
+		})
+	}
+}

--- a/monitoring/inotify_linux.go
+++ b/monitoring/inotify_linux.go
@@ -53,7 +53,7 @@ func (c iNotifyChecker) Check(ctx context.Context, reporter health.Reporter) {
 		reporter.Add(&pb.Probe{
 			Checker: c.Name(),
 			Status:  pb.Probe_Failed,
-			Error:   "Unable to create intofiy watch",
+			Error:   "Unable to create inotify watch",
 		})
 	}
 }

--- a/monitoring/inotify_linux.go
+++ b/monitoring/inotify_linux.go
@@ -26,24 +26,24 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// NewINotifyChecker creates a new health.Checker that tests if inotify watches
+// NewInotifyChecker creates a new health.Checker that tests if inotify watches
 // can be created. This is usually an indication that the system has reached
 // fs.inotify.max_user_instances has been exhausted
-func NewINotifyChecker() health.Checker {
-	return iNotifyChecker{}
+func NewInotifyChecker() health.Checker {
+	return inotifyChecker{}
 }
 
-// iNotifyChecker tries to create an inotify watch, and reports if it fails
-type iNotifyChecker struct {
+// inotifyChecker tries to create an inotify watch, and reports if it fails
+type inotifyChecker struct {
 }
 
 // Name returns name of the checker
-func (c iNotifyChecker) Name() string {
+func (c inotifyChecker) Name() string {
 	return "inotify"
 }
 
 // Check tests whether inotify is working
-func (c iNotifyChecker) Check(ctx context.Context, reporter health.Reporter) {
+func (c inotifyChecker) Check(ctx context.Context, reporter health.Reporter) {
 	fd, err := unix.InotifyInit()
 	if fd < 0 {
 		reporter.Add(&pb.Probe{

--- a/monitoring/inotify_linux_test.go
+++ b/monitoring/inotify_linux_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Gravitational, Inc.
+Copyright 2018 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
I've seen a couple customers run into a scenario where they've run out of inotify watches. Unfortunately, the kernel doesn't have a metric that makes this easy to poll and set a threshold, but we can do a simple test on whether we're able to create a watch or not. This is the same principal used in the prometheus node exporter to detect this type of issue.

Also, I'm planning to add a sysctl check, but will do that as a separate PR.