### PR TITLE
Detect client closed situations and reinit the client.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -101,10 +101,10 @@ func New(config *Config) (Agent, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	clientConfig := &serf.Config{
+	clientConfig := serf.Config{
 		Addr: config.SerfRPCAddr,
 	}
-	client, err := serf.ClientFromConfig(clientConfig)
+	client, err := newRetryingClient(clientConfig)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to connect to serf")
 	}
@@ -433,6 +433,7 @@ func (r *agent) collectStatus(ctx context.Context) (systemStatus *pb.SystemStatu
 
 	members, err := r.serfClient.Members()
 	if err != nil {
+		log.WithError(err).Warn("Failed to query serf members.")
 		return nil, trace.Wrap(err, "failed to query serf members")
 	}
 	members = filterLeft(members)

--- a/agent/server_test.go
+++ b/agent/server_test.go
@@ -645,21 +645,20 @@ func (r *testSerfClient) Members() ([]serf.Member, error) {
 	return r.members, nil
 }
 
-// Stream returns a dummy stream handle.
-func (r *testSerfClient) Stream(filter string, eventc chan<- map[string]interface{}) (serf.StreamHandle, error) {
-	return serf.StreamHandle(0), nil
-}
-
 func (r *testSerfClient) Stop(handle serf.StreamHandle) error {
 	return nil
 }
 
-func (r *testSerfClient) Close() error {
+func (r *testSerfClient) UpdateTags(tags map[string]string, delTags []string) error {
 	return nil
 }
 
 func (r *testSerfClient) Join(peers []string, replay bool) (int, error) {
 	return 0, nil
+}
+
+func (r *testSerfClient) Close() error {
+	return nil
 }
 
 func newTestCache(c *C, clock clockwork.Clock) *testCache {


### PR DESCRIPTION
This is to fix the issues with serf dropping the connection (i.e. as a result of restarting the serf unit).