### PR TITLE
update to golang 1.10.7 to avoid cve-2018-16875

### DIFF
--- a/build.assets/grpc/Dockerfile
+++ b/build.assets/grpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3-stretch
+FROM golang:1.10-stretch
 
 ARG PROTOC_VER
 ARG GOGO_PROTO_TAG


### PR DESCRIPTION
For this Dockerfile, I think we can just point to 1.10, and automatically grab the latest... thoughts?