### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/agent/cache/multiplex/multiplex.go
+++ b/agent/cache/multiplex/multiplex.go
@@ -47,7 +47,7 @@ func (r *multiplexer) UpdateStatus(status *pb.SystemStatus) (err error) {
 	return nil
 }
 
-// Read obtains last known system status
+// RecentStatus reads obtains last known system status
 func (r *multiplexer) RecentStatus() (*pb.SystemStatus, error) {
 	return r.cache.RecentStatus()
 }

--- a/agent/proto/agentpb/timestamp.go
+++ b/agent/proto/agentpb/timestamp.go
@@ -25,7 +25,7 @@ func (ts Timestamp) ToTime() time.Time {
 	return time.Unix(ts.Seconds, int64(ts.Nanoseconds)).UTC()
 }
 
-// TimeToTime creates a new instance of Timestamp from the given time.Time value.
+// TimeToProto creates a new instance of Timestamp from the given time.Time value.
 func TimeToProto(t time.Time) Timestamp {
 	seconds := t.Unix()
 	nanoseconds := int64(t.Sub(time.Unix(seconds, 0)))

--- a/monitoring/collector/utils.go
+++ b/monitoring/collector/utils.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// NewRountripClient returns new roundtrip.Client with root URL
+// NewRoundtripClient returns new roundtrip.Client with root URL
 func NewRoundtripClient(url string, opts ...roundtrip.ClientParam) (*roundtrip.Client, error) {
 	clt, err := roundtrip.NewClient(url, "", opts...)
 	if err != nil {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?