### PR TITLE
Add sysctl checkers that per interface forwarding is enabled

### DIFF
--- a/monitoring/defaults_linux.go
+++ b/monitoring/defaults_linux.go
@@ -74,6 +74,10 @@ func BasicCheckers(checkers ...health.Checker) health.Checker {
 		name: "local",
 		checkers: []health.Checker{
 			NewIPForwardChecker(),
+			NewCNIForwardingChecker(),
+			NewFlannelForwardingChecker(),
+			NewWormholeBridgeForwardingChecker(),
+			NewWormholeWgForwardingChecker(),
 			NewBridgeNetfilterChecker(),
 			NewMayDetachMountsChecker(),
 			DefaultProcessChecker(),

--- a/monitoring/sysctl_checkers.go
+++ b/monitoring/sysctl_checkers.go
@@ -53,6 +53,50 @@ func NewMayDetachMountsChecker() *SysctlChecker {
 	}
 }
 
+// NewCNIForwardingChecker checks if CNI interface has forwarding enabled
+func NewCNIForwardingChecker() *SysctlChecker {
+	return &SysctlChecker{
+		CheckerName:     CNIForwardChecker,
+		Param:           "net.ipv4.conf.cni0.forwarding",
+		Expected:        "1",
+		OnValueMismatch: "ipv4 forwarding is off on interface cni0, see https://www.gravitational.com/docs/faq/#ipv4-forwarding",
+		SkipNotFound:    true, // interface may not exist, so skip if not found
+	}
+}
+
+// NewFlannelForwardingChecker checks if flannel interface has forwarding enabled
+func NewFlannelForwardingChecker() *SysctlChecker {
+	return &SysctlChecker{
+		CheckerName:     FlannelForwardChecker,
+		Param:           "net.ipv4.conf.flannel/1.forwarding",
+		Expected:        "1",
+		OnValueMismatch: "ipv4 forwarding is off on interface flannel.1, see https://www.gravitational.com/docs/faq/#ipv4-forwarding",
+		SkipNotFound:    true, // interface may not exist, so skip if not found
+	}
+}
+
+// NewWormholeBridgeForwardingChecker checks if wormhole-br0 interface has forwarding enabled
+func NewWormholeBridgeForwardingChecker() *SysctlChecker {
+	return &SysctlChecker{
+		CheckerName:     WormholeBridgeForwardChecker,
+		Param:           "net.ipv4.conf.wormhole-br0.forwarding",
+		Expected:        "1",
+		OnValueMismatch: "ipv4 forwarding is off on interface wormhole-br0, see https://www.gravitational.com/docs/faq/#ipv4-forwarding",
+		SkipNotFound:    true, // interface may not exist, so skip if not found
+	}
+}
+
+// NewWormholeWgForwardingChecker checks if wormhole-wg0 interface has forwarding enabled
+func NewWormholeWgForwardingChecker() *SysctlChecker {
+	return &SysctlChecker{
+		CheckerName:     WormholeWgForwardChecker,
+		Param:           "net.ipv4.conf.wormhole-wg0.forwarding",
+		Expected:        "1",
+		OnValueMismatch: "ipv4 forwarding is off on interface wormhole-wg0, see https://www.gravitational.com/docs/faq/#ipv4-forwarding",
+		SkipNotFound:    true, // interface may not exist, so skip if not found
+	}
+}
+
 const (
 	// IPForwardCheckerID is the ID of the checker of ipv4 forwarding
 	IPForwardCheckerID = "ip-forward"
@@ -60,4 +104,12 @@ const (
 	NetfilterCheckerID = "br-netfilter"
 	// MountsCheckerID is the ID of the checker of mounts detaching
 	MountsCheckerID = "may-detach-mounts"
+	// CNIForwardChecker is the ID of the checker of cni interface set to forwarding
+	CNIForwardChecker = "cni0-forwarding"
+	// FlannelForwardChecker is the ID of the checker of flannel interface set to forwarding
+	FlannelForwardChecker = "flannel.1-forwarding"
+	// WormholeBridgeForwardChecker is the ID of the checker of wormhole bridge interface set to forwarding
+	WormholeBridgeForwardChecker = "wormhole-br0-forwarding"
+	// WormholeWgForwardChecker is the ID of the checker of wormhole bridge interface set to forwarding
+	WormholeWgForwardChecker = "wormhole-wg0-forwarding"
 )


### PR DESCRIPTION
Updates https://github.com/gravitational/gravity.e/issues/4087

So, there's 2 potential gaps with these checks:
- I don't check that the advertise-ip interface (like ens4) has forwarding enabled. This would require detecting the name of the interface, but very weirdly, when I tried to test this on a test VM it doesn't seem like it's needed. It possible different versions/configurations of kubernetes or linux may change that, because I would expect forwarding to be needed for external traffic.
- This check can only run after the interface is created, which means we can't try and autofix these failures. A system with `net.ipv4.conf.default.forwarding = 0` will have new interfaces created without forwarding enabled, which we would have to workaround outside of satellite. Alternatively, we could have satellite check / force the default for new interfaces to forwarding = 1. 

Setting the default would be more convenient since it would just set it everywhere as we create interfaces, but I could see some customers not wanting this as a default which is why I opted for the more targeted approach.