### PR TITLE
use third-party DNS resolver that supports root system queries

### DIFF
--- a/monitoring/dns.go
+++ b/monitoring/dns.go
@@ -77,6 +77,7 @@ func (r *DNSChecker) checkWithResolver(
 			if err != nil {
 				reporter.Add(NewProbeFromErr(r.Name(), errorDetail(question, dns.TypeToString[questionType], nameserver), err))
 				checkFailed = true
+				continue
 			}
 			if in.Rcode != dns.RcodeSuccess {
 				if rcode, ok := dns.RcodeToString[in.Rcode]; ok {

--- a/monitoring/dns.go
+++ b/monitoring/dns.go
@@ -19,10 +19,12 @@ package monitoring
 import (
 	"context"
 	"fmt"
-	"net"
 
 	"github.com/gravitational/satellite/agent/health"
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
+
+	"github.com/gravitational/trace"
+	"github.com/miekg/dns"
 )
 
 // DNSMonitor will monitor a list of DNS servers for valid responses
@@ -40,20 +42,19 @@ func (r *DNSChecker) Name() string { return "dns" }
 
 // Check checks if the DNS servers are responding
 func (r *DNSChecker) Check(ctx context.Context, reporter health.Reporter) {
+	nameservers := r.Nameservers
 	if len(r.Nameservers) == 0 {
-		r.checkWithResolver(ctx, reporter, net.DefaultResolver, "")
-		return
+		clientconfig, err := dns.ClientConfigFromFile("/etc/resolv.conf")
+		if err != nil {
+			reporter.Add(NewProbeFromErr(r.Name(), "failed to load /etc/resolv.conf", err))
+			return
+		}
+
+		nameservers = clientconfig.Servers
 	}
 
-	for _, nameserver := range r.Nameservers {
-		resolver := &net.Resolver{
-			PreferGo: true,
-			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-				d := net.Dialer{}
-				return d.DialContext(ctx, "udp", net.JoinHostPort(nameserver, "53"))
-			},
-		}
-		r.checkWithResolver(ctx, reporter, resolver, nameserver)
+	for _, nameserver := range nameservers {
+		r.checkWithResolver(ctx, reporter, nameserver)
 	}
 
 }
@@ -61,26 +62,37 @@ func (r *DNSChecker) Check(ctx context.Context, reporter health.Reporter) {
 func (r *DNSChecker) checkWithResolver(
 	ctx context.Context,
 	reporter health.Reporter,
-	resolver *net.Resolver,
 	nameserver string,
 ) {
 	checkFailed := false
-	for _, question := range r.QuestionA {
-		_, err := resolver.LookupHost(ctx, question)
-		if err != nil {
-			reporter.Add(NewProbeFromErr(r.Name(), errorDetail(question, "A", nameserver), err))
-			checkFailed = true
+	q := new(dns.Msg)
+	q.Id = dns.Id()
+	q.RecursionDesired = true
+	q.Question = make([]dns.Question, 1)
+
+	for questionType, questions := range map[uint16][]string{dns.TypeA: r.QuestionA, dns.TypeNS: r.QuestionNS} {
+		for _, question := range questions {
+			q.Question[0] = dns.Question{question, questionType, dns.ClassINET}
+			in, err := dns.ExchangeContext(ctx, q, fmt.Sprintf("%s:53", nameserver))
+			if err != nil {
+				reporter.Add(NewProbeFromErr(r.Name(), errorDetail(question, dns.TypeToString[questionType], nameserver), err))
+				checkFailed = true
+			}
+			if in.Rcode != dns.RcodeSuccess {
+				if rcode, ok := dns.RcodeToString[in.Rcode]; ok {
+					reporter.Add(
+						NewProbeFromErr(r.Name(), errorDetail(question, dns.TypeToString[questionType], nameserver),
+							trace.BadParameter(rcode)))
+				} else {
+					reporter.Add(
+						NewProbeFromErr(r.Name(), errorDetail(question, dns.TypeToString[questionType], nameserver),
+							trace.BadParameter(fmt.Sprint(in.Rcode))))
+				}
+
+				checkFailed = true
+			}
 		}
 	}
-
-	for _, question := range r.QuestionNS {
-		_, err := resolver.LookupNS(ctx, question)
-		if err != nil {
-			reporter.Add(NewProbeFromErr(r.Name(), errorDetail(question, "NS", nameserver), err))
-			checkFailed = true
-		}
-	}
-
 	if checkFailed {
 		return
 	}
@@ -92,8 +104,5 @@ func (r *DNSChecker) checkWithResolver(
 }
 
 func errorDetail(question, recordType, nameserver string) string {
-	if nameserver == "" {
-		return fmt.Sprintf("failed to resolve '%v' (%v)", question, recordType)
-	}
 	return fmt.Sprintf("failed to resolve '%v' (%v) nameserver %v", question, recordType, nameserver)
 }

--- a/monitoring/dns_test.go
+++ b/monitoring/dns_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/satellite/agent/health"
+	pb "github.com/gravitational/satellite/agent/proto/agentpb"
+	"github.com/stretchr/testify/assert"
+)
+
+type MonitoringSuite struct{}
+
+func TestDnsChecker(t *testing.T) {
+	testCases := []struct {
+		checker DNSChecker
+		probes  health.Probes
+		comment string
+	}{
+		{
+			checker: DNSChecker{
+				QuestionNS:  []string{"."},
+				Nameservers: []string{"1.1.1.1"},
+			},
+			probes: health.Probes{
+				{
+					Checker: "dns",
+					Status:  pb.Probe_Running,
+				},
+			},
+			comment: "test root system query (requires internet access)",
+		},
+		{
+			checker: DNSChecker{
+				QuestionA:   []string{"google.com."},
+				Nameservers: []string{"1.1.1.1"},
+			},
+			probes: health.Probes{
+				{
+					Checker: "dns",
+					Status:  pb.Probe_Running,
+				},
+			},
+			comment: "test known name (requires internet access)",
+		},
+		{
+			checker: DNSChecker{
+				QuestionA:   []string{"fdbnmfbvcnjfdblkbjcklkfldgkld.com."},
+				Nameservers: []string{"1.1.1.1"},
+			},
+			probes: health.Probes{
+				{
+					Checker: "dns",
+					Status:  pb.Probe_Failed,
+					Error:   "NXDOMAIN",
+					Detail:  "failed to resolve 'fdbnmfbvcnjfdblkbjcklkfldgkld.com.' (A) nameserver 1.1.1.1",
+				},
+			},
+			comment: "test non existant name (requires internet access)",
+		},
+	}
+
+	for _, testCase := range testCases {
+		var reporter health.Probes
+		testCase.checker.Check(context.TODO(), &reporter)
+		assert.Equal(t, reporter, testCase.probes, testCase.comment)
+	}
+}

--- a/monitoring/dns_test.go
+++ b/monitoring/dns_test.go
@@ -61,7 +61,7 @@ func TestDnsChecker(t *testing.T) {
 		},
 		{
 			checker: DNSChecker{
-				QuestionA:   []string{"fdbnmfbvcnjfdblkbjcklkfldgkld.com."},
+				QuestionA:   []string{"test.invalid."},
 				Nameservers: []string{"1.1.1.1"},
 			},
 			probes: health.Probes{
@@ -69,7 +69,7 @@ func TestDnsChecker(t *testing.T) {
 					Checker: "dns",
 					Status:  pb.Probe_Failed,
 					Error:   "NXDOMAIN",
-					Detail:  "failed to resolve 'fdbnmfbvcnjfdblkbjcklkfldgkld.com.' (A) nameserver 1.1.1.1",
+					Detail:  "failed to resolve 'test.invalid.' (A) nameserver 1.1.1.1",
 				},
 			},
 			comment: "test non existant name (requires internet access)",

--- a/monitoring/modules_linux_test.go
+++ b/monitoring/modules_linux_test.go
@@ -27,7 +27,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-type MonitoringSuite struct{}
+
 
 var _ = Suite(&MonitoringSuite{})
 


### PR DESCRIPTION
Updates gravitational/gravity#257

This switches the satellite DNS testing from using the default golang resolver to a more flexible external resolver. The primary reason to do this, is the embedded golang resolver doesn't consider `.` to be a valid DNS name, which prevents us from being able to run root system queries.

Due to the leaking DNS queries, we need to test the upstream DNS servers, and I think the most reliable way to do so is to perform a root system query. 