### PR TITLE
implement checker for file-nr

### DIFF
--- a/monitoring/sysctl.go
+++ b/monitoring/sysctl.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/gravitational/satellite/agent/health"
@@ -95,6 +96,85 @@ func (c *SysctlChecker) Check(ctx context.Context, reporter health.Reporter) {
 	reporter.Add(NewProbeFromErr(c.CheckerName,
 		fmt.Sprintf("failed to query sysctl parameter %s", c.Param), trace.Wrap(err)))
 }
+
+// NewFSNRChecker creates a new checker that checks that the minimum number of file handles can be allocated
+func NewFSNRChecker(min int) health.Checker {
+	return &FSNRChecker{
+		Min: min,
+	}
+}
+
+// FSNRChecker checks the file-nr sysctl for allocatable file handles
+type FSNRChecker struct {
+	// Min is the minimum number of free descriptors before raising a health check report
+	Min int
+}
+
+// Name returns name of checker
+func (c *FSNRChecker) Name() string {
+	return FSNRCheckerID
+}
+
+// Check will load the sysctl and verify the parameter
+func (c *FSNRChecker) Check(ctx context.Context, reporter health.Reporter) {
+	content, err := Sysctl("fs.file-nr")
+	if err != nil {
+		reporter.Add(NewProbeFromErr(FSNRCheckerID, fmt.Sprintf(
+			"Failed to read sysctl fs.file-nr"), trace.Wrap(err)))
+		return
+	}
+
+	c.check(ctx, reporter, content)
+}
+
+// check will parse the provided fileNr and validate that there are enough free file handles
+func (c *FSNRChecker) check(ctx context.Context, reporter health.Reporter, fileNr string) {
+	// parsing reference
+	// https://www.kernel.org/doc/Documentation/sysctl/fs.txt
+	split := strings.Split(fileNr, "\t")
+	if len(split) != 3 {
+		reporter.Add(NewProbeFromErr(FSNRCheckerID, fmt.Sprintf(
+			"fs.file-nr expected 3 fields: %v", fileNr), trace.BadParameter("expected 3 fields")))
+		return
+	}
+
+	allocatedFH, err := strconv.Atoi(split[0])
+	if err != nil {
+		reporter.Add(NewProbeFromErr(FSNRCheckerID, fmt.Sprintf(
+			"%v is not a number", split[0]), trace.Wrap(err)))
+		return
+	}
+	// ignore unused filehandles
+	maxFH, err := strconv.Atoi(split[2])
+	if err != nil {
+		reporter.Add(NewProbeFromErr(FSNRCheckerID, fmt.Sprintf(
+			"%v is not a number", split[2]), trace.Wrap(err)))
+		return
+	}
+
+	// calculate number of additional file handles that can be allocated (max - allocated)
+	additionalFH := maxFH - allocatedFH
+
+	if additionalFH < c.Min {
+		reporter.Add(&pb.Probe{
+			Checker: FSNRCheckerID,
+			Detail:  fmt.Sprintf("Available filehandles (%v) is low. Please increase fs.file-max sysctl.", additionalFH),
+			Status:  pb.Probe_Failed,
+		})
+		return
+	}
+
+	reporter.Add(&pb.Probe{
+		Checker: FSNRCheckerID,
+		Status:  pb.Probe_Running,
+	})
+
+}
+
+const (
+	// FSNRCheckerID is the ID of the checker of number of open file descriptors
+	FSNRCheckerID = "file-nr"
+)
 
 // Sysctl returns kernel parameter by reading proc/sys
 func Sysctl(name string) (string, error) {

--- a/monitoring/sysctl.go
+++ b/monitoring/sysctl.go
@@ -97,29 +97,29 @@ func (c *SysctlChecker) Check(ctx context.Context, reporter health.Reporter) {
 		fmt.Sprintf("failed to query sysctl parameter %s", c.Param), trace.Wrap(err)))
 }
 
-// NewFSNRChecker creates a new checker that checks that the minimum number of file handles can be allocated
-func NewFSNRChecker(min int) health.Checker {
-	return &FSNRChecker{
+// NewFileHandleAllocatableChecker creates a new checker that checks that the minimum number of file handles can be allocated
+func NewFileHandleAllocatableChecker(min int) health.Checker {
+	return &FileHandleAllocatableChecker{
 		Min: min,
 	}
 }
 
-// FSNRChecker checks the file-nr sysctl for allocatable file handles
-type FSNRChecker struct {
+// FileHandleAllocatableChecker checks the file-nr sysctl for allocatable file handles
+type FileHandleAllocatableChecker struct {
 	// Min is the minimum number of free descriptors before raising a health check report
 	Min int
 }
 
 // Name returns name of checker
-func (c *FSNRChecker) Name() string {
-	return FSNRCheckerID
+func (c *FileHandleAllocatableChecker) Name() string {
+	return FileHandleAllocatableCheckerID
 }
 
 // Check will load the sysctl and verify the parameter
-func (c *FSNRChecker) Check(ctx context.Context, reporter health.Reporter) {
+func (c *FileHandleAllocatableChecker) Check(ctx context.Context, reporter health.Reporter) {
 	content, err := Sysctl("fs.file-nr")
 	if err != nil {
-		reporter.Add(NewProbeFromErr(FSNRCheckerID, fmt.Sprintf(
+		reporter.Add(NewProbeFromErr(FileHandleAllocatableCheckerID, fmt.Sprintf(
 			"Failed to read sysctl fs.file-nr"), trace.Wrap(err)))
 		return
 	}
@@ -128,52 +128,52 @@ func (c *FSNRChecker) Check(ctx context.Context, reporter health.Reporter) {
 }
 
 // check will parse the provided fileNr and validate that there are enough free file handles
-func (c *FSNRChecker) check(ctx context.Context, reporter health.Reporter, fileNr string) {
+func (c *FileHandleAllocatableChecker) check(ctx context.Context, reporter health.Reporter, fileNr string) {
 	// parsing reference
 	// https://www.kernel.org/doc/Documentation/sysctl/fs.txt
-	split := strings.Split(fileNr, "\t")
+	split := strings.Fields(fileNr)
 	if len(split) != 3 {
-		reporter.Add(NewProbeFromErr(FSNRCheckerID, fmt.Sprintf(
+		reporter.Add(NewProbeFromErr(FileHandleAllocatableCheckerID, fmt.Sprintf(
 			"fs.file-nr expected 3 fields: %v", fileNr), trace.BadParameter("expected 3 fields")))
 		return
 	}
 
-	allocatedFH, err := strconv.Atoi(split[0])
+	allocated, err := strconv.Atoi(split[0])
 	if err != nil {
-		reporter.Add(NewProbeFromErr(FSNRCheckerID, fmt.Sprintf(
+		reporter.Add(NewProbeFromErr(FileHandleAllocatableCheckerID, fmt.Sprintf(
 			"%v is not a number", split[0]), trace.Wrap(err)))
 		return
 	}
 	// ignore unused filehandles
-	maxFH, err := strconv.Atoi(split[2])
+	max, err := strconv.Atoi(split[2])
 	if err != nil {
-		reporter.Add(NewProbeFromErr(FSNRCheckerID, fmt.Sprintf(
+		reporter.Add(NewProbeFromErr(FileHandleAllocatableCheckerID, fmt.Sprintf(
 			"%v is not a number", split[2]), trace.Wrap(err)))
 		return
 	}
 
 	// calculate number of additional file handles that can be allocated (max - allocated)
-	additionalFH := maxFH - allocatedFH
+	additional := max - allocated
 
-	if additionalFH < c.Min {
+	if additional < c.Min {
 		reporter.Add(&pb.Probe{
-			Checker: FSNRCheckerID,
-			Detail:  fmt.Sprintf("Available filehandles (%v) is low. Please increase fs.file-max sysctl.", additionalFH),
+			Checker: FileHandleAllocatableCheckerID,
+			Detail:  fmt.Sprintf("Available filehandles (%v) is low. Please increase fs.file-max sysctl.", additional),
 			Status:  pb.Probe_Failed,
 		})
 		return
 	}
 
 	reporter.Add(&pb.Probe{
-		Checker: FSNRCheckerID,
+		Checker: FileHandleAllocatableCheckerID,
 		Status:  pb.Probe_Running,
 	})
 
 }
 
 const (
-	// FSNRCheckerID is the ID of the checker of number of open file descriptors
-	FSNRCheckerID = "file-nr"
+	// FileHandleAllocatableCheckerID is the ID of the checker of number of open file descriptors
+	FileHandleAllocatableCheckerID = "file-nr"
 )
 
 // Sysctl returns kernel parameter by reading proc/sys

--- a/monitoring/sysctl_test.go
+++ b/monitoring/sysctl_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package monitoring
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/satellite/agent/health"
+	pb "github.com/gravitational/satellite/agent/proto/agentpb"
+	"github.com/stretchr/testify/assert"
+)
+
+type MonitoringSuite struct{}
+
+func TestFSNRChecker(t *testing.T) {
+	testCases := []struct {
+		sysctl  string
+		checker FSNRChecker
+		probes  health.Probes
+		comment string
+	}{
+		{
+			sysctl: "2976	0	1533180",
+			checker: FSNRChecker{
+				Min: 1000,
+			},
+			probes: health.Probes{
+				{
+					Checker: "file-nr",
+					Status:  pb.Probe_Running,
+				},
+			},
+			comment: "healthy test",
+		},
+		{
+			sysctl: "3000	0	3000",
+			checker: FSNRChecker{
+				Min: 1000,
+			},
+			probes: health.Probes{
+				{
+					Checker: "file-nr",
+					Status:  pb.Probe_Failed,
+					Detail:  "Available filehandles (0) is low. Please increase fs.file-max sysctl.",
+				},
+			},
+			comment: "all handles in use",
+		},
+		{
+			sysctl: "3001	0	3000",
+			checker: FSNRChecker{
+				Min: 1000,
+			},
+			probes: health.Probes{
+				{
+					Checker: "file-nr",
+					Status:  pb.Probe_Failed,
+					Detail:  "Available filehandles (-1) is low. Please increase fs.file-max sysctl.",
+				},
+			},
+			comment: "filehandles exceed max",
+		},
+		{
+			sysctl: "3001	0	3000	10",
+			checker: FSNRChecker{
+				Min: 1000,
+			},
+			probes: health.Probes{
+				{
+					Checker: "file-nr",
+					Status:  pb.Probe_Failed,
+					Detail:  "fs.file-nr expected 3 fields: 3001\t0\t3000\t10",
+					Error:   "expected 3 fields",
+				},
+			},
+			comment: "unexpected number of fields",
+		},
+		{
+			sysctl: "invalid	0	3000",
+			checker: FSNRChecker{
+				Min: 1000,
+			},
+			probes: health.Probes{
+				{
+					Checker: "file-nr",
+					Status:  pb.Probe_Failed,
+					Detail:  "invalid is not a number",
+					Error:   "strconv.Atoi: parsing \"invalid\": invalid syntax",
+				},
+			},
+			comment: "allocatedFH invalid",
+		},
+		{
+			sysctl: "3001	0	invalid",
+			checker: FSNRChecker{
+				Min: 1000,
+			},
+			probes: health.Probes{
+				{
+					Checker: "file-nr",
+					Status:  pb.Probe_Failed,
+					Detail:  "invalid is not a number",
+					Error:   "strconv.Atoi: parsing \"invalid\": invalid syntax",
+				},
+			},
+			comment: "maxFH invalid",
+		},
+	}
+
+	for _, testCase := range testCases {
+		var reporter health.Probes
+		testCase.checker.check(context.TODO(), &reporter, testCase.sysctl)
+		assert.Equal(t, reporter, testCase.probes, testCase.comment)
+	}
+}

--- a/monitoring/sysctl_test.go
+++ b/monitoring/sysctl_test.go
@@ -26,16 +26,16 @@ import (
 
 type MonitoringSuite struct{}
 
-func TestFSNRChecker(t *testing.T) {
+func TestFileHandleAllocatableChecker(t *testing.T) {
 	testCases := []struct {
 		sysctl  string
-		checker FSNRChecker
+		checker FileHandleAllocatableChecker
 		probes  health.Probes
 		comment string
 	}{
 		{
 			sysctl: "2976	0	1533180",
-			checker: FSNRChecker{
+			checker: FileHandleAllocatableChecker{
 				Min: 1000,
 			},
 			probes: health.Probes{
@@ -48,7 +48,7 @@ func TestFSNRChecker(t *testing.T) {
 		},
 		{
 			sysctl: "3000	0	3000",
-			checker: FSNRChecker{
+			checker: FileHandleAllocatableChecker{
 				Min: 1000,
 			},
 			probes: health.Probes{
@@ -62,7 +62,7 @@ func TestFSNRChecker(t *testing.T) {
 		},
 		{
 			sysctl: "3001	0	3000",
-			checker: FSNRChecker{
+			checker: FileHandleAllocatableChecker{
 				Min: 1000,
 			},
 			probes: health.Probes{
@@ -76,7 +76,7 @@ func TestFSNRChecker(t *testing.T) {
 		},
 		{
 			sysctl: "3001	0	3000	10",
-			checker: FSNRChecker{
+			checker: FileHandleAllocatableChecker{
 				Min: 1000,
 			},
 			probes: health.Probes{
@@ -91,7 +91,7 @@ func TestFSNRChecker(t *testing.T) {
 		},
 		{
 			sysctl: "invalid	0	3000",
-			checker: FSNRChecker{
+			checker: FileHandleAllocatableChecker{
 				Min: 1000,
 			},
 			probes: health.Probes{
@@ -106,7 +106,7 @@ func TestFSNRChecker(t *testing.T) {
 		},
 		{
 			sysctl: "3001	0	invalid",
-			checker: FSNRChecker{
+			checker: FileHandleAllocatableChecker{
 				Min: 1000,
 			},
 			probes: health.Probes{


### PR DESCRIPTION
Updates https://github.com/gravitational/gravity.e/issues/4044

Implements a checker for open file handles vs max file handles. I set it up so it will throw a health check failure if the number of allocatable file handles falls below a minimum value. IE if the max filehandles is 100, and the minimum value is set to 10, then when more than 90 filehandles are in use the health check fill fail.