### PR TITLE
Remove port range check for 30000-32767

### DIFF
--- a/monitoring/defaults_linux.go
+++ b/monitoring/defaults_linux.go
@@ -30,7 +30,6 @@ func DefaultPortChecker() health.Checker {
 		PortRange{Protocol: protoTCP, From: 4001, To: 4001, Description: "etcd"},
 		PortRange{Protocol: protoTCP, From: 7001, To: 7001, Description: "etcd"},
 		PortRange{Protocol: protoTCP, From: 6443, To: 6443, Description: "kubernetes API server"},
-		PortRange{Protocol: protoTCP, From: 30000, To: 32767, Description: "kubernetes internal services range"},
 		PortRange{Protocol: protoTCP, From: 10248, To: 10255, Description: "kubernetes internal services range"},
 		PortRange{Protocol: protoTCP, From: 5000, To: 5000, Description: "docker registry"},
 		PortRange{Protocol: protoTCP, From: 3022, To: 3025, Description: "teleport internal ssh control panel"},


### PR DESCRIPTION
Kubernetes by default has the range of 30000-32767 for NodePort assignment. However, it is not appropriate to ensure (and fail the install) if something is bound within this range, because Kubernetes will actually only choose open ports when assigning a NodePort. Additionally, this range can be changed via configuration, so hardcoding verification of it being unused with no way of changing it is problematic.

It would be great to backport this to 5.5.x as well, as currently we have to maintain a fork of Gravity.

See also https://community.gravitational.com/t/port-usage-and-verification/163/3
See also https://github.com/gravitational/gravity/pull/451