### PR TITLE
Bump healthz timeout.

### DIFF
--- a/monitoring/healthz.go
+++ b/monitoring/healthz.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gravitational/trace"
 )
 
-const healthzCheckTimeout = 1 * time.Second
+const healthzCheckTimeout = 5 * time.Second
 
 // HTTPResponseChecker is a function that can validate service health
 // from the provided response


### PR DESCRIPTION
To see if this alleviates issues with docker/registry/etcd healthz checks failing intermittently.