### PR TITLE
Detect client closed situations and reinit the client. (#95)

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -101,10 +101,10 @@ func New(config *Config) (Agent, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	clientConfig := &serf.Config{
+	clientConfig := serf.Config{
 		Addr: config.SerfRPCAddr,
 	}
-	client, err := serf.ClientFromConfig(clientConfig)
+	client, err := newSerfClient(clientConfig)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to connect to serf")
 	}
@@ -433,6 +433,7 @@ func (r *agent) collectStatus(ctx context.Context) (systemStatus *pb.SystemStatu
 
 	members, err := r.serfClient.Members()
 	if err != nil {
+		log.WithError(err).Warn("Failed to query serf members.")
 		return nil, trace.Wrap(err, "failed to query serf members")
 	}
 	members = filterLeft(members)

--- a/agent/serf.go
+++ b/agent/serf.go
@@ -17,6 +17,9 @@ limitations under the License.
 package agent
 
 import (
+	"sync"
+
+	"github.com/gravitational/trace"
 	serf "github.com/hashicorp/serf/client"
 )
 
@@ -25,15 +28,106 @@ import (
 type serfClient interface {
 	// Members lists members of the serf cluster.
 	Members() ([]serf.Member, error)
-	// Stream subcribes the caller to the serf event stream.
-	// Filter can be used to restrict the events.
-	// Returns an opaque handle to be used with Stop.
-	Stream(filter string, eventc chan<- map[string]interface{}) (serf.StreamHandle, error)
 	// Stop cancels the serf event delivery and removes the subscription.
 	Stop(serf.StreamHandle) error
 	// Close closes the client.
 	Close() error
 	// Join attempts to join an existing serf cluster identified by peers.
 	// Replay controls if previous user events are replayed once this node has joined the cluster.
+	// Returns the number of nodes joined
 	Join(peers []string, replay bool) (int, error)
+	// UpdateTags will modify the tags on a running serf agent
+	UpdateTags(tags map[string]string, delTags []string) error
+}
+
+func newSerfClient(clientConfig serf.Config) (*retryingClient, error) {
+	client, err := reinit(clientConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &retryingClient{
+		client: client,
+		config: clientConfig,
+	}, nil
+}
+
+// Members lists members of the serf cluster.
+func (r *retryingClient) Members() ([]serf.Member, error) {
+	if err := r.reinit(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	r.RLock()
+	defer r.RUnlock()
+	return r.client.Members()
+}
+
+// Stop cancels the serf event delivery and removes the subscription.
+func (r *retryingClient) Stop(handle serf.StreamHandle) error {
+	if err := r.reinit(); err != nil {
+		return trace.Wrap(err)
+	}
+	r.RLock()
+	defer r.RUnlock()
+	return r.client.Stop(handle)
+}
+
+// Join attempts to join an existing serf cluster identified by peers.
+// Replay controls if previous user events are replayed once this node has joined the cluster.
+// Returns the number of nodes joined
+func (r *retryingClient) Join(peers []string, replay bool) (int, error) {
+	if err := r.reinit(); err != nil {
+		return 0, trace.Wrap(err)
+	}
+	r.RLock()
+	defer r.RUnlock()
+	return r.client.Join(peers, replay)
+}
+
+// UpdateTags will modify the tags on a running serf agent
+func (r *retryingClient) UpdateTags(tags map[string]string, delTags []string) error {
+	if err := r.reinit(); err != nil {
+		return trace.Wrap(err)
+	}
+	r.RLock()
+	defer r.RUnlock()
+	return r.client.UpdateTags(tags, delTags)
+}
+
+// Close closes the client
+func (r *retryingClient) Close() error {
+	r.RLock()
+	defer r.RUnlock()
+	if r.client.IsClosed() {
+		return nil
+	}
+	return r.client.Close()
+}
+
+func (r *retryingClient) reinit() (err error) {
+	r.Lock()
+	defer r.Unlock()
+	client := r.client
+	if !client.IsClosed() {
+		return nil
+	}
+	client, err = reinit(r.config)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	r.client = client
+	return nil
+}
+
+func reinit(clientConfig serf.Config) (*serf.RPCClient, error) {
+	client, err := serf.ClientFromConfig(&clientConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return client, nil
+}
+
+type retryingClient struct {
+	sync.RWMutex
+	client *serf.RPCClient
+	config serf.Config
 }

--- a/agent/server_test.go
+++ b/agent/server_test.go
@@ -645,21 +645,20 @@ func (r *testSerfClient) Members() ([]serf.Member, error) {
 	return r.members, nil
 }
 
-// Stream returns a dummy stream handle.
-func (r *testSerfClient) Stream(filter string, eventc chan<- map[string]interface{}) (serf.StreamHandle, error) {
-	return serf.StreamHandle(0), nil
-}
-
 func (r *testSerfClient) Stop(handle serf.StreamHandle) error {
 	return nil
 }
 
-func (r *testSerfClient) Close() error {
+func (r *testSerfClient) UpdateTags(tags map[string]string, delTags []string) error {
 	return nil
 }
 
 func (r *testSerfClient) Join(peers []string, replay bool) (int, error) {
 	return 0, nil
+}
+
+func (r *testSerfClient) Close() error {
+	return nil
 }
 
 func newTestCache(c *C, clock clockwork.Clock) *testCache {


### PR DESCRIPTION
Backport #95 by customer request
Updates https://github.com/gravitational/gravity/issues/754

* Detect client closed situations and reinit the client.
This is to fix the issues with serf dropping the connection.

* Protect client with a mutex

* Address review comments