### PR TITLE
Log errors returned from serve(...)

### DIFF
--- a/agent/server.go
+++ b/agent/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
 	serf "github.com/hashicorp/serf/client"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -126,7 +127,12 @@ func newRPCServer(agent *agent, caFile, certFile, keyFile string, rpcAddrs []str
 	handler := grpcHandlerFunc(server, healthzHandler)
 
 	for _, addr := range rpcAddrs {
-		go serve(addr, certFile, keyFile, tlsConfig, handler)
+		go func(address string) {
+			err := serve(address, certFile, keyFile, tlsConfig, handler)
+			if err != nil {
+				log.Error(trace.DebugReport(err))
+			}
+		}(addr)
 	}
 
 	return server, nil

--- a/agent/server.go
+++ b/agent/server.go
@@ -128,8 +128,7 @@ func newRPCServer(agent *agent, caFile, certFile, keyFile string, rpcAddrs []str
 
 	for _, addr := range rpcAddrs {
 		go func(address string) {
-			err := serve(address, certFile, keyFile, tlsConfig, handler)
-			if err != nil {
+			if err := serve(address, certFile, keyFile, tlsConfig, handler); err != nil {
 				log.Error(trace.DebugReport(err))
 			}
 		}(addr)

--- a/agent/server.go
+++ b/agent/server.go
@@ -129,7 +129,7 @@ func newRPCServer(agent *agent, caFile, certFile, keyFile string, rpcAddrs []str
 	for _, addr := range rpcAddrs {
 		go func(address string) {
 			if err := serve(address, certFile, keyFile, tlsConfig, handler); err != nil {
-				log.Error(trace.DebugReport(err))
+				log.WithError(err).Errorf("Failed to serve on %v.", address)
 			}
 		}(addr)
 	}

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -39,7 +39,9 @@ func runAgent(config *agent.Config, monitoringConfig *config, peers []string) er
 	}
 	defer monitoringAgent.Close()
 
-	addCheckers(monitoringAgent, monitoringConfig)
+	if err = addCheckers(monitoringAgent, monitoringConfig); err != nil {
+		return trace.Wrap(err)
+	}
 	if err = monitoringAgent.Start(); err != nil {
 		return trace.Wrap(err)
 	}

--- a/cmd/agent/checkers.go
+++ b/cmd/agent/checkers.go
@@ -98,9 +98,9 @@ func addToMaster(node agent.Agent, config *config, kubeConfig monitoring.KubeCon
 	}
 
 	timeDriftHealth, err := monitoring.TimeDriftHealth(monitoring.TimeDriftCheckerConfig{
-		CAFile:     config.agentCAFile,
-		CertFile:   config.agentCertFile,
-		KeyFile:    config.agentKeyFile,
+		CAFile:     node.GetConfig().CAFile,
+		CertFile:   node.GetConfig().CertFile,
+		KeyFile:    node.GetConfig().KeyFile,
 		SerfClient: serfClient,
 		SerfMember: serfMember,
 	})


### PR DESCRIPTION
Addresses gravitational/gravity#806

Okay to just log returned errors from `serve` or should we handle errors and shutdown satellite agent in case of error?
