### PR TITLE
Record status/probe in case of timeout.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -222,7 +222,7 @@ type agent struct {
 }
 
 // DialRPC returns RPC client for the provided Serf member.
-type DialRPC func(*serf.Member) (*client, error)
+type DialRPC func(context.Context, *serf.Member) (*client, error)
 
 // GetConfig returns the agent configuration.
 func (r *agent) GetConfig() Config {
@@ -516,7 +516,7 @@ func (r *agent) getLocalStatus(ctx context.Context, local serf.Member, respc cha
 
 // getStatusFrom obtains node status from the node identified by member.
 func (r *agent) getStatusFrom(ctx context.Context, member serf.Member, respc chan<- *statusResponse) {
-	client, err := r.dialRPC(&member)
+	client, err := r.dialRPC(ctx, &member)
 	resp := &statusResponse{member: member}
 	if err != nil {
 		resp.err = trace.Wrap(err)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -55,6 +55,7 @@ type Agent interface {
 	health.CheckerRepository
 }
 
+// Config defines satellite configuration.
 type Config struct {
 	// Name of the agent unique within the cluster.
 	// Names are used as a unique id within a serf cluster, so

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -364,7 +364,7 @@ func runChecker(ctx context.Context, checker health.Checker, probeCh chan<- heal
 
 	log.Debugf("Running checker %q.", checker.Name())
 
-	checkResult := make(chan health.Probes)
+	checkResult := make(chan health.Probes, 1)
 	go func() {
 		var probes health.Probes
 		checker.Check(ctx, &probes)

--- a/agent/client.go
+++ b/agent/client.go
@@ -45,7 +45,7 @@ type client struct {
 }
 
 // NewClientFunc defines a function that returns RPC agent client.
-type NewClientFunc func(addr, caFile, certFile, keyFile string) (*client, error)
+type NewClientFunc func(ctx context.Context, addr, caFile, certFile, keyFile string) (*client, error)
 
 // NewClient creates a agent RPC client to the given address
 // using the specified client certificate certFile

--- a/agent/client.go
+++ b/agent/client.go
@@ -102,7 +102,6 @@ func NewClientWithCreds(ctx context.Context, addr string, creds credentials.Tran
 		ctx,
 		addr,
 		grpc.WithTransportCredentials(creds),
-		grpc.WithBlock(),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to dial")

--- a/agent/server.go
+++ b/agent/server.go
@@ -203,7 +203,7 @@ func grpcHandlerFunc(rpcServer *server, other http.Handler) http.Handler {
 // DefaultDialRPC is a default RPC client factory function.
 // It creates a new client based on address details from the specific serf member.
 func DefaultDialRPC(caFile, certFile, keyFile string) DialRPC {
-	return func(member *serf.Member) (*client, error) {
-		return NewClient(fmt.Sprintf("%s:%d", member.Addr.String(), RPCPort), caFile, certFile, keyFile)
+	return func(ctx context.Context, member *serf.Member) (*client, error) {
+		return NewClient(ctx, fmt.Sprintf("%s:%d", member.Addr.String(), RPCPort), caFile, certFile, keyFile)
 	}
 }

--- a/agent/server.go
+++ b/agent/server.go
@@ -35,7 +35,7 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-// Default RPC port.
+// RPCPort specifies the default RPC port.
 const RPCPort = 7575 // FIXME: use serf to discover agents
 
 // RPCServer is the interface that defines the interaction with an agent via RPC.

--- a/agent/server_test.go
+++ b/agent/server_test.go
@@ -581,8 +581,8 @@ func (r *AgentSuite) newAgent(node string, rpcPort int, members []serf.Member,
 // testDialRPC is a test implementation of the dialRPC interface,
 // that creates an RPC client bound to localhost.
 func testDialRPC(port int, certFile, keyFile string) DialRPC {
-	return func(member *serf.Member) (*client, error) {
-		return newClient(fmt.Sprintf(":%d", port), "agent", certFile, certFile, keyFile)
+	return func(ctx context.Context, member *serf.Member) (*client, error) {
+		return newClient(ctx, fmt.Sprintf(":%d", port), "agent", certFile, certFile, keyFile)
 	}
 }
 

--- a/monitoring/timedrift.go
+++ b/monitoring/timedrift.go
@@ -188,7 +188,7 @@ func (c *timeDriftChecker) check(ctx context.Context, r health.Reporter) (probes
 
 // * Compare abs(Drift) with the threshold.
 func (c *timeDriftChecker) getTimeDrift(ctx context.Context, node serf.Member) (time.Duration, error) {
-	agentClient, err := c.getAgentClient(node)
+	agentClient, err := c.getAgentClient(ctx, node)
 	if err != nil {
 		return 0, trace.Wrap(err)
 	}
@@ -267,14 +267,14 @@ func (c *timeDriftChecker) shouldCheckNode(node serf.Member) bool {
 }
 
 // getAgentClient returns Satellite agent client for the provided node.
-func (c *timeDriftChecker) getAgentClient(node serf.Member) (agent.Client, error) {
+func (c *timeDriftChecker) getAgentClient(ctx context.Context, node serf.Member) (agent.Client, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	clientI, exists := c.clients.Get(node.Addr.String())
 	if exists {
 		return clientI.(agent.Client), nil
 	}
-	client, err := c.DialRPC(&node)
+	client, err := c.DialRPC(ctx, &node)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
This PR addresses the "correct status" portion of gravitational/gravity#750 .

While collecting status, if there are any pending status queries when the context times out, they will not be included in the recorded status.
Same situation with the health checks. Any probes that timeout will not be recorded.

Instead of ignoring the node statuses and health checks that timed out, satellite should record the statuses and probes with information indicating that the query failed due to timeout.

This change will cause satellite to no longer log the warnings on timeout. If we'd still like to log the warnings after timeout, we could use a WaitGroup and a separate goroutine to check if all status queries have returned by the time the context times out.

In the situation when a network partition is created, the 'node-status' and 'kube-apiserver' checks are unable to complete and causes the entire status of the node to be dropped.

This is what `gravity status` may have returned before the change:
```
Cluster status: degraded
Cluster image:  telekube, version 7.0.0-alpha.1.122
Join token:     longtoken
Last completed operation:
    * operation_install (4d662bd6-2e4f-4bc4-b349-d16ba5b70369)
      started:          Tue Oct  8 19:09 UTC (3 hours ago)
      completed:        Tue Oct  8 19:09 UTC (3 hours ago)
Cluster endpoints:
    * Authentication gateway:
        - 172.28.128.3:32009
        - 172.28.128.4:32009
        - 172.28.128.5:32009
    * Cluster management URL:
        - https://172.28.128.3:32009
        - https://172.28.128.4:32009
        - https://172.28.128.5:32009
Cluster nodes:  dev.test
    Masters:
        * gravity1 / 172.28.128.4 / node
            Status:     degraded
        * gravity2 / 172.28.128.5 / node
            Status:     offline
    Nodes:
        * gravity0 / 172.28.128.3
            Status:     offline
...
```

This is what `gravity status` might return after the change:
```
Cluster status: degraded
Cluster image:  telekube, version 7.0.0-alpha.1.153
Join token:     longtoken
Last completed operation:
    * operation_install (1b047653-c0a6-45c0-aa8e-59b305913dff)
      started:          Wed Oct 23 22:23 UTC (1 day ago)
      completed:        Wed Oct 23 22:24 UTC (1 day ago)
Cluster endpoints:
    * Authentication gateway:
        - 172.28.128.3:32009
        - 172.28.128.5:32009
        - 172.28.128.4:32009
    * Cluster management URL:
        - https://172.28.128.3:32009
        - https://172.28.128.5:32009
        - https://172.28.128.4:32009
Cluster nodes:  dev.test
    Masters:
        * gravity0 / 172.28.128.3
            Status:     degraded
            [×]         kube-apiserver (checker timed out)
            [×]         node-status (checker timed out)
        * gravity1 / 172.28.128.4
            Status:     degraded
            [×]         kube-apiserver (checker timed out)
            [×]         node-status (checker timed out)
        * gravity2 / 172.28.128.5
            Status:     offline
...
```
The status now correctly records both nodes as 'degraded'  and all three nodes as 'master' nodes. The failed health checks are also recorded and specifies that they failed due to timeout.