### PR TITLE
NewClient requires context

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -418,7 +418,7 @@ const statusQueryReplyTimeout = 30 * time.Second
 const nodeTimeout = 25 * time.Second
 
 // checksTimeout specifies the amount of time to wait for a check to complete.
-// The checksTimeout is smaller than the nodeTimeout so that the checker has
+// The checksTimeout is smaller than the nodeTimeout so that the checks
 // can return results before the deadline.
 const checksTimeout = 20 * time.Second
 

--- a/cmd/agent/status.go
+++ b/cmd/agent/status.go
@@ -40,14 +40,16 @@ const statusTimeout = 5 * time.Second
 // The output is prettified if prettyPrint is true.
 func status(RPCPort int, local, prettyPrint bool, caFile, certFile, keyFile string) (ok bool, err error) {
 	RPCAddr := fmt.Sprintf("127.0.0.1:%d", RPCPort)
-	client, err := agent.NewClient(RPCAddr, caFile, certFile, keyFile)
+
+	ctx, cancel := context.WithTimeout(context.Background(), statusTimeout)
+	defer cancel()
+
+	client, err := agent.NewClient(ctx, RPCAddr, caFile, certFile, keyFile)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
 	var statusJson []byte
 	var statusBlob interface{}
-	ctx, cancel := context.WithTimeout(context.Background(), statusTimeout)
-	defer cancel()
 	if local {
 		status, err := client.LocalStatus(ctx)
 		if err != nil {


### PR DESCRIPTION
- Forgot to run satellite test. Satellite agent NewClient requires a context.
- Typo