### PR TITLE
Modify boot config check to comply with context

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,5 @@
+Health Checks
+
+*   AWS
+*   Boot Config
+*   CGroups

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,5 +1,0 @@
-Health Checks
-
-*   AWS
-*   Boot Config
-*   CGroups

--- a/monitoring/boot_config_linux.go
+++ b/monitoring/boot_config_linux.go
@@ -80,10 +80,10 @@ func (c *bootConfigParamChecker) Check(ctx context.Context, reporter health.Repo
 	select {
 	case probes := <-probesCh:
 		health.AddFrom(reporter, probes)
-		if reporter.NumProbes() != 0 {
-			return
+		if reporter.NumProbes() == 0 {
+			// add a successful probe if boot config checks are skipped
+			reporter.Add(NewSuccessProbe(bootConfigParamID))
 		}
-		reporter.Add(NewSuccessProbe(bootConfigParamID))
 	case err := <-errCh:
 		reporter.Add(NewProbeFromErr(c.Name(), "failed to validate boot configuration", err))
 	case <-ctx.Done():


### PR DESCRIPTION
- Modify boot config checker to comply with provided context.
- Add test case to verifty checker complies with context.
- Is there a reason why some of the checkers are exported while some are not, like bootConfigParamChecker? 