### PR TITLE
Modify cgroup checker to comply with context

### DIFF
--- a/monitoring/cgroup.go
+++ b/monitoring/cgroup.go
@@ -116,7 +116,7 @@ func listProcMounts(ctx context.Context) ([]mountPoint, error) {
 func consistentRead(ctx context.Context, filename string, attempts int) ([]byte, error) {
 	file, err := os.Open(filename)
 	if err != nil {
-		return nil, trace.Wrap(err, "unable to open %s", filename)
+		return nil, trace.ConvertSystemError(err)
 	}
 	defer file.Close()
 

--- a/monitoring/cgroup.go
+++ b/monitoring/cgroup.go
@@ -58,6 +58,7 @@ func (c *cgroupChecker) Check(ctx context.Context, reporter health.Reporter) {
 	probes, err := c.check(ctx)
 	if err != nil {
 		probes.Add(NewProbeFromErr(c.Name(), "failed to validate cgroup mounts", err))
+		return
 	}
 	health.AddFrom(reporter, probes)
 }

--- a/utils/reader.go
+++ b/utils/reader.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"io"
+)
+
+// ReaderWithContext wraps a reader with a context.
+type ReaderWithContext struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+// NewReaderWithContext intializes and returns a new ReaderWithContext.
+func NewReaderWithContext(ctx context.Context, reader io.Reader) *ReaderWithContext {
+	return &ReaderWithContext{ctx: ctx, reader: reader}
+}
+
+// Read reads from the underlying reader. Return without reading if context is
+// done.
+//
+// Implements io.Reader
+func (r *ReaderWithContext) Read(p []byte) (n int, err error) {
+	select {
+	case <-r.ctx.Done():
+		return 0, r.ctx.Err()
+	default:
+		return r.reader.Read(p)
+	}
+}

--- a/utils/reader_test.go
+++ b/utils/reader_test.go
@@ -1,0 +1,52 @@
+/*
+
+Copyright 2019 Gravitational, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"io/ioutil"
+	"strings"
+
+	. "gopkg.in/check.v1"
+)
+
+type ReaderSuite struct{}
+
+var _ = Suite(&ReaderSuite{})
+
+func (s *ReaderSuite) TestReadAll(c *C) {
+	testString := "Reader Test"
+
+	reader := NewReaderWithContext(context.TODO(), strings.NewReader(testString))
+	content, err := ioutil.ReadAll(reader)
+
+	c.Assert(err, IsNil)
+	c.Assert(string(content), Equals, testString, Commentf("Read all content"))
+}
+
+func (s *ReaderSuite) TestContextCanceled(c *C) {
+	testString := "Reader Test"
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	cancel()
+
+	reader := NewReaderWithContext(ctx, strings.NewReader(testString))
+	_, err := ioutil.ReadAll(reader)
+
+	c.Assert(err, Not(IsNil))
+	c.Assert(err.Error(), Equals, "context canceled", Commentf("Reader context canceled"))
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into to "go test" runner for utils tests.
+func TestUtils(t *testing.T) { TestingT(t) }


### PR DESCRIPTION
- Use consistent receiver name 'c' for Checkers.
- Modify cgroup checker to comply with the provided context.
- Add test case to verify checker complies with context.