### PR TITLE
Add nethealth checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 *.swp
 *.test
+*.vscode

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -993,6 +993,8 @@
     "github.com/mitchellh/go-ps",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
+    "github.com/prometheus/client_model/go",
+    "github.com/prometheus/common/expfmt",
     "github.com/prometheus/procfs",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -217,12 +217,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:418247f700939c99867b42639d985686ba229fd9f8ee9e119c7cc3ffde6e0fe3"
+  digest = "1:dc84545f9f2a442b14864f2f7e54ae556cae53bd437a05a456572fea9e73cc87"
   name = "github.com/gravitational/trace"
   packages = ["."]
   pruneopts = "UT"
-  revision = "a535a178675fb4a11ba74818491754a8c5575dd6"
-  version = "1.1.8"
+  revision = "dd5b2e8eae86d31f6273ff3ac46d5b15edd6d6be"
+  version = "1.1.10"
 
 [[projects]]
   digest = "1:01cb46669ee737a700ca9a0968ffe2aa820f262e5f49e1e54f8bfc441650ea8e"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -60,7 +60,7 @@ required = [
   name = "github.com/gravitational/roundtrip"
 
 [[constraint]]
-  version = "1.1.8"
+  version = "=1.1.10"
   name = "github.com/gravitational/trace"
 
 [[constraint]]

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -530,7 +530,7 @@ func (r *agent) recycleLoop(ctx context.Context) {
 // updates the health status of the cluster by querying status of other active
 // cluster members.
 func (r *agent) statusUpdateLoop(ctx context.Context) {
-	ticker := r.Clock.NewTicker(statusUpdateTimeout)
+	ticker := r.Clock.NewTicker(StatusUpdateTimeout)
 	defer ticker.Stop()
 
 	for {
@@ -566,7 +566,7 @@ func (r *agent) updateStatus(ctx context.Context) error {
 // collectStatus obtains the cluster status by querying statuses of
 // known cluster members.
 func (r *agent) collectStatus(ctx context.Context) (systemStatus *pb.SystemStatus, err error) {
-	ctx, cancel := context.WithTimeout(ctx, statusUpdateTimeout)
+	ctx, cancel := context.WithTimeout(ctx, StatusUpdateTimeout)
 	defer cancel()
 
 	systemStatus = &pb.SystemStatus{

--- a/agent/constants.go
+++ b/agent/constants.go
@@ -57,8 +57,8 @@ const (
 	// to be stored into the timeline.
 	updateTimelineTimeout = 5 * time.Second
 
-	// statusUpdateTimeout is the amount of time to wait between status update collections.
-	statusUpdateTimeout = 30 * time.Second
+	// StatusUpdateTimeout is the amount of time to wait between status update collections.
+	StatusUpdateTimeout = 30 * time.Second
 
 	// recycleTimeout is the amount of time to wait between recycle attempts.
 	// Recycle is a request to clean up / remove stale data that backends can choose to

--- a/build.go
+++ b/build.go
@@ -39,7 +39,7 @@ var (
 	nethealthRegistryImage = env("NETHEALTH_REGISTRY_IMAGE", "quay.io/gravitational/nethealth-dev")
 
 	// baseImage is the base OS image to use for containers
-	baseImage = "ubuntu:18.10"
+	baseImage = "ubuntu:19.10"
 
 	// buildVersion allows override of the version string from env variable
 	buildVersion = env("BUILD_VERSION", "")

--- a/lib/nethealth/nethealth.go
+++ b/lib/nethealth/nethealth.go
@@ -487,7 +487,7 @@ func (s *Server) processAck(e messageWrapper) error {
 		return nil
 	default:
 		//unexpected / unknown
-		return trace.BadParameter("received unexpected icmp message type").(trace.Error).AddField("type", e.message.Type)
+		return trace.BadParameter("received unexpected icmp message type").AddField("type", e.message.Type)
 	}
 
 	switch pkt := e.message.Body.(type) {
@@ -496,8 +496,10 @@ func (s *Server) processAck(e messageWrapper) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if pkt.Seq != peer.echoCounter {
-			return trace.BadParameter("Response sequence doesn't match latest request.")
+		if uint16(pkt.Seq) != uint16(peer.echoCounter) {
+			return trace.BadParameter("response sequence doesn't match latest request.").
+				AddField("expected", uint16(peer.echoCounter)).
+				AddField("received", uint16(pkt.Seq))
 		}
 
 		rtt := e.rxTime.Sub(peer.echoTime)
@@ -508,7 +510,8 @@ func (s *Server) processAck(e messageWrapper) error {
 		s.WithFields(logrus.Fields{
 			"peer_name": peer.name,
 			"peer_addr": peer.addr,
-			"id":        pkt.Seq,
+			"counter":   peer.echoCounter,
+			"seq":       uint16(peer.echoCounter),
 			"rtt":       rtt,
 		}).Debug("Ack.")
 	default:

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -193,7 +193,10 @@ func (c *nethealthChecker) isHealthy(series []int64) bool {
 		return true
 	}
 
-	// Increase in number of timeouts at each data point indicates network issue.
+	// series contains time series data of the running total of timeouts for a peer.
+	// If the counter is increasing at each data point, that means requests to
+	// this peer have been timing consistently throughout this interval. This
+	// should indicate that there is a network issue.
 	for i := 0; i < c.SeriesCapacity-1; i++ {
 		if series[i] >= series[i+1] {
 			return true

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -176,7 +176,7 @@ func (c *nethealthChecker) updatePeer(peer string, incomingData networkData) err
 		return trace.Wrap(err)
 	}
 
-	// Calcluate counter delta since last check and replace total.
+	// Calculate counter delta since last check and replace total.
 	requestInc := incomingData.requestTotal - storedData.prevRequestTotal
 	timeoutInc := incomingData.timeoutTotal - storedData.prevTimeoutTotal
 	storedData.prevRequestTotal = incomingData.requestTotal
@@ -467,7 +467,7 @@ const (
 	packetLossThreshold = 0.20 // packet loss > 20% is unhealthy
 )
 
-// nethealthLabelSelector specifies label selector used when querying for
+// nethealthLabelSelector defines label selector used when querying for
 // nethealth pods.
 var nethealthLabelSelector = mustLabelSelector(metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 	MatchLabels: map[string]string{

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -275,18 +275,15 @@ func (c *nethealthChecker) isHealthy(peer string) (healthy bool, err error) {
 		return true, nil
 	}
 
-	// Total requests/timeouts over the interval.
-	totalRequestInc := 0.0
-	totalTimeoutInc := 0.0
+	// If the packet loss percentage is above the packet loss threshold thoroughout
+	// the entire interval, overlay network communication to that peer will be
+	// considered unhealthy.
 	for i := 0; i < c.seriesCapacity; i++ {
-		totalRequestInc += storedData.requestInc[i]
-		totalTimeoutInc += storedData.timeoutInc[i]
+		if (storedData.timeoutInc[i] / storedData.requestInc[i]) <= packetLossThreshold {
+			return true, nil
+		}
 	}
-
-	// The overlay network is considered healthy if the packet loss percentage
-	// is below the set packet loss threshold.
-	healthy = (totalTimeoutInc / totalRequestInc) <= packetLossThreshold
-	return healthy, nil
+	return false, nil
 }
 
 // parseMetrics parses the MetricsFamilies and returns the structured network

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -78,7 +78,7 @@ type nethealthChecker struct {
 	// Mutex locks access to peerStats
 	sync.Mutex
 	// peerStats maps a peer to its recorded nethealth stats.
-	peerStats netStats
+	peerStats *netStats
 }
 
 // NewNethealthChecker returns a new nethealth checker.
@@ -302,7 +302,7 @@ func parseMetrics(metricFamilies map[string]*dto.MetricFamily) (map[string]netwo
 	}
 
 	// Each peer should have a request counter and timeout counter pair.
-	// If lenghts are unequal, we are missing data.
+	// If lengths are unequal, we are missing data.
 	if len(echoRequests) != len(echoTimeouts) {
 		return nil, trace.BadParameter("recieved %d timeout counters and %d request counters",
 			len(echoRequests), len(echoTimeouts))
@@ -365,12 +365,12 @@ type netStats struct {
 }
 
 // newNetStats constructs a new netStats.
-func newNetStats(capacity int) netStats {
-	return netStats{TTLMap: holster.NewTTLMap(capacity)}
+func newNetStats(capacity int) *netStats {
+	return &netStats{TTLMap: holster.NewTTLMap(capacity)}
 }
 
 // Get returns the peerData for the specified peer.
-func (r netStats) Get(peer string) (data peerData, err error) {
+func (r *netStats) Get(peer string) (data peerData, err error) {
 	r.Lock()
 	defer r.Unlock()
 	if value, ok := r.TTLMap.Get(peer); ok {
@@ -382,7 +382,7 @@ func (r netStats) Get(peer string) (data peerData, err error) {
 }
 
 // Set maps the specified peer and data.
-func (r netStats) Set(peer string, data peerData) error {
+func (r *netStats) Set(peer string, data peerData) error {
 	r.Lock()
 	defer r.Unlock()
 	return r.TTLMap.Set(peer, data, netStatsTTLSeconds)

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gravitational/satellite/agent"
 	"github.com/gravitational/satellite/agent/health"
+	"github.com/gravitational/satellite/utils"
 
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
@@ -151,7 +152,7 @@ func (c *nethealthChecker) check(ctx context.Context, reporter health.Reporter) 
 func (c *nethealthChecker) getNethealthAddr() (addr string, err error) {
 	pods, err := c.Client.CoreV1().Pods(nethealthNamespace).List(metav1.ListOptions{})
 	if err != nil {
-		return addr, rigging.ConvertError(err) // this will convert error to a proper trace error, e.g. trace.NotFound
+		return addr, utils.ConvertError(err) // this will convert error to a proper trace error, e.g. trace.NotFound
 	}
 
 	// Find nethealth pod with matching host ip address.

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -17,6 +17,7 @@ limitations under the License.
 package monitoring
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -26,6 +27,7 @@ import (
 
 	"github.com/gravitational/satellite/agent"
 	"github.com/gravitational/satellite/agent/health"
+	pb "github.com/gravitational/satellite/agent/proto/agentpb"
 	"github.com/gravitational/satellite/utils"
 
 	"github.com/gravitational/roundtrip"
@@ -35,7 +37,6 @@ import (
 	"github.com/prometheus/common/expfmt"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -108,25 +109,36 @@ func (c *nethealthChecker) Name() string {
 func (c *nethealthChecker) Check(ctx context.Context, reporter health.Reporter) {
 	err := c.check(ctx, reporter)
 	if err != nil {
+		log.WithError(err).Warn("Failed to verify nethealth")
 		reporter.Add(NewProbeFromErr(c.Name(), "failed to verify nethealth", err))
 		return
 	}
-	reporter.Add(NewSuccessProbe(c.Name()))
+	if reporter.NumProbes() == 0 {
+		reporter.Add(NewSuccessProbe(c.Name()))
+	}
 }
 
 func (c *nethealthChecker) check(ctx context.Context, reporter health.Reporter) error {
 	addr, err := c.getNethealthAddr()
 	if trace.IsNotFound(err) {
-		log.Debug("Nethealth pod was not found.")
+		log.WithError(err).Warn("Nethealth pod was not found.")
 		return nil // pod was not found, log and treat gracefully
 	}
 	if err != nil {
 		return trace.Wrap(err) // received unexpected error, maybe network-related, will add error probe above
 	}
 
-	netData, err := fetchNethealthMetrics(ctx, addr)
+	resp, err := fetchNethealthMetrics(ctx, addr)
 	if err != nil {
 		return trace.Wrap(err, "failed to fetch nethealth metrics")
+	}
+
+	netData, err := parseMetrics(resp)
+	if err != nil {
+		log.WithError(err).
+			WithField("nethealth-metrics", string(resp)).
+			Error("Received incomplete set of metrics. Could be due to a bug in nethealth or a change in labels.")
+		return nil
 	}
 
 	updated, err := c.updateStats(netData)
@@ -141,18 +153,22 @@ func (c *nethealthChecker) check(ctx context.Context, reporter health.Reporter) 
 func (c *nethealthChecker) getNethealthAddr() (addr string, err error) {
 	opts := metav1.ListOptions{
 		LabelSelector: nethealthLabelSelector.String(),
-		FieldSelector: fields.OneTermEqualSelector("spec.nodeName", c.AdvertiseIP).String(),
-		Limit:         1,
 	}
 	pods, err := c.Client.CoreV1().Pods(nethealthNamespace).List(opts)
 	if err != nil {
 		return addr, utils.ConvertError(err) // this will convert error to a proper trace error, e.g. trace.NotFound
 	}
 
-	if len(pods.Items) == 0 {
-		return addr, trace.NotFound("unable to find local nethealth pod")
+	for _, pod := range pods.Items {
+		if pod.Status.HostIP == c.AdvertiseIP {
+			if pod.Status.PodIP == "" {
+				return addr, trace.NotFound("local nethealth pod IP has not been assigned yet.")
+			}
+			return fmt.Sprintf("http://%s:%d", pod.Status.PodIP, c.NethealthPort), nil
+		}
 	}
-	return fmt.Sprintf("http://%s:%d", pods.Items[0].Status.PodIP, c.NethealthPort), nil
+
+	return addr, trace.NotFound("unable to find nethealth pod running on host %s", c.AdvertiseIP)
 }
 
 // updateStats updates netStats with new incoming data.
@@ -227,9 +243,20 @@ func (c *nethealthChecker) verifyNethealth(peers []string, reporter health.Repor
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if !healthy {
-			reporter.Add(NewProbeFromErr(c.Name(), nethealthDetail(peer), nil))
+		if healthy {
+			continue
 		}
+
+		// Report last recorded packet loss percentage
+		data, err := c.peerStats.Get(peer)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if len(data.packetLoss) == 0 {
+			continue
+		}
+		packetLoss := data.packetLoss[len(data.packetLoss)-1]
+		reporter.Add(nethealthFailureProbe(c.Name(), peer, packetLoss))
 	}
 	return nil
 }
@@ -259,9 +286,21 @@ func (c *nethealthChecker) isHealthy(peer string) (healthy bool, err error) {
 	return false, nil
 }
 
+// nethealthFailureProbe constructs a probe that represents failed nethealth check
+// against the specified peer.
+func nethealthFailureProbe(name, peer string, packetLoss float64) *pb.Probe {
+	return &pb.Probe{
+		Checker: name,
+		Detail: fmt.Sprintf("overlay packet loss for node %s is higher than the allowed threshold of %.2f%%: %.2f%%",
+			peer, thresholdPercent, packetLoss*100),
+		Status:   pb.Probe_Failed,
+		Severity: pb.Probe_Warning,
+	}
+}
+
 // fetchNethealthMetrics collects the network metrics from the nethealth pod
-// specified by addr. Returns mapping of peer to networkData.
-func fetchNethealthMetrics(ctx context.Context, addr string) (map[string]networkData, error) {
+// specified by addr. Returns the resp as an array of bytes.
+func fetchNethealthMetrics(ctx context.Context, addr string) ([]byte, error) {
 	client, err := roundtrip.NewClient(addr, "")
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to connect to nethealth service at %s.", addr)
@@ -283,27 +322,19 @@ func fetchNethealthMetrics(ctx context.Context, addr string) (map[string]network
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	var parser expfmt.TextParser
-	metricFamilies, err := parser.TextToMetricFamilies(resp.Reader())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	netData, err := parseMetrics(metricFamilies)
-	if err != nil {
-		log.WithError(err).
-			WithField("nethealth-metrics", string(resp.Bytes())).
-			Error("Received incomplete set of metrics. Could be due to a bug in nethealth or a change in labels.")
-		return nil, trace.Wrap(err)
-	}
-
-	return netData, nil
+	return resp.Bytes(), nil
 }
 
-// parseMetrics parses the MetricsFamilies and returns the structured network
-// data. data maps a peer to its total request counter and total timeout counter.
-func parseMetrics(metricFamilies map[string]*dto.MetricFamily) (map[string]networkData, error) {
+// parseMetrics parses the provided data and returns the structured network
+// data. The returned networkData maps a peer to its total request counter and
+// total timeout counter.
+func parseMetrics(data []byte) (map[string]networkData, error) {
+	var parser expfmt.TextParser
+	metricFamilies, err := parser.TextToMetricFamilies(bytes.NewReader(data))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// echoRequests maps a peer to the current running total number of requests sent to that peer.
 	echoRequests, err := parseCounter(metricFamilies, echoRequestLabel)
 	if err != nil {
@@ -364,11 +395,6 @@ func getPeerName(labels []*dto.LabelPair) (peer string, err error) {
 		}
 	}
 	return "", trace.NotFound("unable to find %s label", peerLabel)
-}
-
-// nethealthDetail returns a failed probe detail message.
-func nethealthDetail(name string) string {
-	return fmt.Sprintf("overlay network communication failure with %s", name)
 }
 
 // netStats holds nethealth data for a peer.
@@ -466,6 +492,10 @@ const (
 	// loss is consistently observed to be above this threshold over the entire
 	// interval, network communication will be considered unhealthy.
 	packetLossThreshold = 0.20
+
+	// thresholdPercent converts the packetLossThreshold into a percent value.
+	// Used for logging purposes.
+	thresholdPercent = packetLossThreshold * 100
 )
 
 // nethealthLabelSelector defines label selector used when querying for

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -180,11 +180,7 @@ func (c *nethealthChecker) verifyNethealth(names []string, reporter health.Repor
 		}
 
 		if !c.isHealthy(series) {
-			reporter.Add(NewProbeFromErr(
-				c.Name(),
-				fmt.Sprintf("overlay network communication failure with %s", name),
-				trace.Wrap(err),
-			))
+			reporter.Add(NewProbeFromErr(c.Name(), nethealthDetail(name), nil))
 		}
 	}
 	return nil
@@ -302,6 +298,11 @@ func getPeerName(labels []*dto.LabelPair) (peer string, err error) {
 		}
 	}
 	return "", trace.NotFound("unable to find required peer label")
+}
+
+// nethealthDetail returns a failed probe detail message.
+func nethealthDetail(name string) string {
+	return fmt.Sprintf("overlay network communication failure with %s", name)
 }
 
 type nethealthMetric struct {

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -1,0 +1,293 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/gravitational/satellite/agent/health"
+
+	"github.com/gravitational/roundtrip"
+	"github.com/gravitational/trace"
+	"github.com/mailgun/holster"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+// NethealthConfig specifies configuration for a nethealth checker.
+type NethealthConfig struct {
+	// NodeName specifies the name of the node this checker is running on.
+	// Should match the k8s node name.
+	NodeName string
+
+	// NethealthServiceAddr specifies the nethealth service address used to
+	// to collect network metrics.
+	NethealthServiceAddr string
+
+	// SeriesCapacity specifies the max number of data points to store in a time
+	// series interval.
+	SeriesCapacity int
+}
+
+// CheckAndSetDefaults validates that this configuration is correct and sets
+// value defaults where necessary.
+func (c *NethealthConfig) CheckAndSetDefaults() error {
+	var errors []error
+	if c.NodeName == "" {
+		errors = append(errors, trace.BadParameter("node name must be provided"))
+	}
+	if c.NethealthServiceAddr == "" {
+		errors = append(errors, trace.BadParameter("nethealth service address must be provided"))
+	}
+	if c.SeriesCapacity == 0 {
+		c.SeriesCapacity = defaultSeriesCapacity
+	}
+	return trace.NewAggregate(errors...)
+}
+
+// nethealthChecker checks network communication between peers.
+type nethealthChecker struct {
+	// lock access to timeoutStats
+	sync.Mutex
+
+	// timeoutStats maps a peer to a time series data interval containing the
+	// number of echo timeouts received by the specific peer for a set interval.
+	timeoutStats *holster.TTLMap
+
+	// NethealthConfig contains caller specified nethealth checker configuration
+	// values.
+	NethealthConfig
+}
+
+// NewNethealthChecker returns a new nethealth checker.
+func NewNethealthChecker(config NethealthConfig) (*nethealthChecker, error) {
+	return &nethealthChecker{
+		timeoutStats:    holster.NewTTLMap(timeoutStatsCapacity),
+		NethealthConfig: config,
+	}, nil
+}
+
+// Name returns this checker name
+// Implements health.Checker
+func (c *nethealthChecker) Name() string {
+	return nethealthCheckerID
+}
+
+// Check verifies the network is healthy.
+// Implements health.Checker
+func (c *nethealthChecker) Check(ctx context.Context, reporter health.Reporter) {
+	if err := c.check(ctx); err != nil {
+		reporter.Add(NewProbeFromErr(c.Name(), "failed nethealth test", trace.Wrap(err)))
+		return
+	}
+	reporter.Add(NewSuccessProbe(c.Name()))
+}
+
+func (c *nethealthChecker) check(ctx context.Context) error {
+	b, err := fetchMetrics(ctx, c.NethealthServiceAddr)
+	if err != nil {
+		return trace.Wrap(err, "failed to fetch metrics")
+	}
+
+	metrics, err := parseMetrics(bytes.NewReader(b))
+	if err != nil {
+		return trace.Wrap(err, "failed to parse metrics")
+	}
+
+	updated, err := c.updateStats(metrics)
+	if err != nil {
+		return trace.Wrap(err, "failed to update nethealth timeout stats")
+	}
+
+	if err := c.verifyNethealth(updated); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// updateStats updates the timeout data with new data points collected in
+// the provided metrics. Returns a list containing the updated keys.
+func (c *nethealthChecker) updateStats(metrics []*dto.Metric) (updated []string, err error) {
+	var errors []error
+	for _, metric := range metrics {
+		nodeName, peerName, err := getNames(metric.GetLabel())
+		if err != nil {
+			errors = append(errors, trace.Wrap(err))
+			continue
+		}
+
+		// Only update metrics relevant to this node.
+		if c.NodeName != nodeName {
+			continue
+		}
+
+		series, err := c.getTimeoutSeries(peerName)
+		if err != nil {
+			errors = append(errors, trace.Wrap(err))
+			continue
+		}
+
+		// Keep only the last `seriesCapacity` number of data points.
+		if len(series) >= c.SeriesCapacity {
+			series = series[1:]
+		}
+		series = append(series, int64(metric.GetCounter().GetValue()))
+
+		if err := c.setTimeoutSeries(peerName, series); err != nil {
+			errors = append(errors, trace.Wrap(err))
+		}
+
+		// Record updated nodes to be returned for use in later network verification step.
+		updated = append(updated, peerName)
+	}
+	return updated, trace.NewAggregate(errors...)
+}
+
+// verifyNethealth verifies that the network communication is healthy for the
+// nodes specified by the provided list of names.
+func (c *nethealthChecker) verifyNethealth(names []string) error {
+	var errors []error
+	for _, name := range names {
+		series, err := c.getTimeoutSeries(name)
+		if err != nil {
+			errors = append(errors, trace.Wrap(err))
+			continue
+		}
+
+		if !c.isHealthy(series) {
+			errors = append(errors, trace.BadParameter("network communication failure with %s", name))
+		}
+	}
+	return trace.NewAggregate(errors...)
+}
+
+// isHealthy returns false if the number of timeouts increases at each data point.
+func (c *nethealthChecker) isHealthy(series []int64) bool {
+	// Checker has not collected enough data yet to check network health.
+	if len(series) < c.SeriesCapacity {
+		return true
+	}
+
+	// Increase in number of timeouts at each data point indicates network issue.
+	for i := 0; i < c.SeriesCapacity-1; i++ {
+		if series[i] >= series[i+1] {
+			return true
+		}
+	}
+
+	return false
+}
+
+// getTimeoutSeries returns the time series data mapped to the specified name.
+// Returns an empty slice if name was not previously mapped.
+func (c *nethealthChecker) getTimeoutSeries(name string) (series []int64, err error) {
+	c.Lock()
+	defer c.Unlock()
+	if value, ok := c.timeoutStats.Get(name); ok {
+		if series, ok = value.([]int64); !ok {
+			return series, trace.BadParameter("couldn't parse time series as []int64; got type %T", value)
+		}
+	}
+	return series, nil
+}
+
+// setTimeoutSeries maps the name to the timeout series.
+func (c *nethealthChecker) setTimeoutSeries(name string, series []int64) error {
+	c.Lock()
+	defer c.Unlock()
+	return c.timeoutStats.Set(name, series, timeoutStatsTTLSeconds)
+}
+
+// fetchMetrics collects the network metrics from the nethealth service.
+// Metrics are returned as an array of bytes.
+func fetchMetrics(ctx context.Context, addr string) ([]byte, error) {
+	addr = "http://" + addr
+
+	client, err := roundtrip.NewClient(addr, "/metrics", roundtrip.HTTPClient(&http.Client{}))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	resp, err := client.Get(ctx, fmt.Sprintf("%s/%s", addr, "metrics"), url.Values{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return resp.Bytes(), nil
+}
+
+// parseMetrics parses input from the provided reader and returns the metrics
+// for the 'nethealth_echo_timeout_total' counter.
+func parseMetrics(input io.Reader) ([]*dto.Metric, error) {
+	// requestTimeoutName defines the metric family name of the relevant nethealth counter
+	const requestTimeoutName = "nethealth_echo_timeout_total"
+
+	var parser expfmt.TextParser
+	metricsFamilies, err := parser.TextToMetricFamilies(input)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if mf, ok := metricsFamilies[requestTimeoutName]; ok {
+		return mf.GetMetric(), nil
+	}
+	return nil, trace.NotFound("%s metrics not found", requestTimeoutName)
+}
+
+// getNames extracts the 'node_name' and 'peer_name' values from the provided
+// labels.
+func getNames(labels []*dto.LabelPair) (node, peer string, err error) {
+	for _, label := range labels {
+		name := label.GetName()
+		if peerLabel == name {
+			peer = label.GetValue()
+		}
+		if nodeLabel == name {
+			node = label.GetValue()
+		}
+		if node != "" && peer != "" {
+			return node, peer, nil
+		}
+	}
+	return "", "", trace.NotFound("unable to find required labels")
+}
+
+const (
+	nethealthCheckerID = "nethealth-checker"
+	peerLabel          = "peer_name"
+	nodeLabel          = "node_name"
+
+	// defaultSeriesCapacity  defines the default capacity of a time series
+	// interval.
+	defaultSeriesCapacity = 10
+
+	// timeoutStatsCapacity sets the number of TTLMaps that can be stored.
+	// This will be the size of the cluster -1.
+	timeoutStatsCapacity = 1000
+
+	// timeoutStatsTTLSeconds defines the time to live in seconds for the
+	// stored timeout stats. This ensures the checker does not hold on to
+	// unsed information when a member leaves the cluster.
+	timeoutStatsTTLSeconds = 5 * 60 // 5 minutes
+)

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -292,6 +292,7 @@ func parseMetrics(metricFamilies map[string]*dto.MetricFamily) (packetLossPercen
 			len(echoTimeouts), len(echoRequests))
 	}
 
+	packetLossPercentages = make(nethealthData)
 	for _, peer := range echoTimeouts.getPeers() {
 		totalTimeouts := echoTimeouts[peer]
 		totalRequests, ok := echoRequests[peer]
@@ -311,6 +312,7 @@ func parseCounter(metricFamilies map[string]*dto.MetricFamily, label string) (co
 		return nil, trace.NotFound("%s metrics not found", label)
 	}
 
+	counters = make(nethealthData)
 	for _, m := range mf.GetMetric() {
 		peerName, err := getPeerName(m.GetLabel())
 		if err != nil {

--- a/monitoring/nethealth_test.go
+++ b/monitoring/nethealth_test.go
@@ -1,0 +1,128 @@
+package monitoring
+
+import (
+	"github.com/gravitational/satellite/lib/test"
+
+	dto "github.com/prometheus/client_model/go"
+	. "gopkg.in/check.v1"
+)
+
+type NethealthSuite struct{}
+
+var _ = Suite(&NethealthSuite{})
+
+// TestUpdateTimeoutStats verifies the checker can properly record timeout
+// data points from available metrics.
+func (s *NethealthSuite) TestUpdateTimeoutStats(c *C) {
+	var testCases = []struct {
+		comment  CommentInterface
+		expected []int64
+		data     []float64
+	}{
+		{
+			comment:  Commentf("Expected all data points to be recorded."),
+			expected: []int64{0, 0, 0, 0, 0},
+			data:     []float64{0, 0, 0, 0, 0},
+		},
+		{
+			comment:  Commentf("Expected oldest data point to be removed"),
+			expected: []int64{0, 0, 0, 0, 0},
+			data:     []float64{1, 0, 0, 0, 0, 0},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		checker, err := s.newNethealthChecker()
+		c.Assert(err, IsNil)
+
+		for _, count := range testCase.data {
+			updated, err := checker.updateStats(s.newMetricsWithCount(count))
+			c.Assert(err, IsNil, testCase.comment)
+			c.Assert(updated, test.DeepCompare, []string{testNode}, testCase.comment)
+		}
+
+		series, err := checker.getTimeoutSeries(testNode)
+		c.Assert(err, IsNil, testCase.comment)
+		c.Assert(series, test.DeepCompare, testCase.expected, testCase.comment)
+	}
+}
+
+// TestNethealthChecker verifies nethealth checker can properly detect
+// healthy/unhealthy network.
+func (s *NethealthSuite) TestNethealthVerification(c *C) {
+	var testCases = []struct {
+		comment  CommentInterface
+		expected Checker
+		data     []int64
+	}{
+		{
+			comment:  Commentf("Expected healthy network check. Not enough data points."),
+			expected: IsNil,
+			data:     []int64{0, 1, 2},
+		},
+		{
+			comment:  Commentf("Expected healthy network check. No timeouts."),
+			expected: IsNil,
+			data:     []int64{0, 0, 0, 0, 0},
+		},
+		{
+			comment:  Commentf("Expected healthy network check. Timeouts do not increase for a long enough duration"),
+			expected: IsNil,
+			data:     []int64{0, 1, 2, 3, 3},
+		},
+		{
+			comment:  Commentf("Expected unhealthy network check. Timeouts increase at each interval."),
+			expected: Not(IsNil),
+			data:     []int64{0, 1, 2, 3, 4},
+		},
+	}
+
+	checker, err := s.newNethealthChecker()
+	c.Assert(err, IsNil)
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		c.Assert(checker.setTimeoutSeries(testNode, testCase.data), IsNil, testCase.comment)
+		c.Assert(checker.verifyNethealth([]string{testNode}), testCase.expected, testCase.comment)
+	}
+}
+
+// newNethealthChecker returns a new nethealth checker to be used for testing.
+func (s *NethealthSuite) newNethealthChecker() (*nethealthChecker, error) {
+	config := NethealthConfig{
+		NodeName:             testNode,
+		NethealthServiceAddr: "mock-service-addr",
+		SeriesCapacity:       testCapacity,
+	}
+	return NewNethealthChecker(config)
+}
+
+// netMetrics creates new metrics with the provided count.
+func (s *NethealthSuite) newMetricsWithCount(count float64) []*dto.Metric {
+	return s.newMetrics(testNode, testNode, count)
+}
+
+// newMetrics creates new metrics with the provided values.
+func (s *NethealthSuite) newMetrics(nodeValue, peerValue string, count float64) []*dto.Metric {
+	peer := peerLabel
+	node := nodeLabel
+
+	return []*dto.Metric{
+		&dto.Metric{
+			Label: []*dto.LabelPair{
+				&dto.LabelPair{Name: &peer, Value: &peerValue},
+				&dto.LabelPair{Name: &node, Value: &nodeValue},
+			},
+			Counter: &dto.Counter{Value: &count},
+		},
+	}
+}
+
+const (
+	// testNode is used for 'node_name' or 'peer_name' value in test cases.
+	testNode = "test-node"
+	// testCapacity specifies the time series capacity used for test cases.
+	testCapacity = 5
+)

--- a/monitoring/nethealth_test.go
+++ b/monitoring/nethealth_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package monitoring
 
 import (
@@ -92,14 +108,14 @@ func (s *NethealthSuite) TestNethealthVerification(c *C) {
 // newNethealthChecker returns a new nethealth checker to be used for testing.
 func (s *NethealthSuite) newNethealthChecker() (*nethealthChecker, error) {
 	config := NethealthConfig{
-		NodeName:             testNode,
-		NethealthServiceAddr: "mock-service-addr",
-		SeriesCapacity:       testCapacity,
+		NodeName:       testNode,
+		NethealthName:  "mock-service-addr",
+		SeriesCapacity: testCapacity,
 	}
 	return NewNethealthChecker(config)
 }
 
-// netMetrics creates new metrics with the provided count.
+// netMetricsWithCount creates new metrics with the provided count.
 func (s *NethealthSuite) newMetricsWithCount(count float64) []*dto.Metric {
 	return s.newMetrics(testNode, testNode, count)
 }
@@ -107,13 +123,11 @@ func (s *NethealthSuite) newMetricsWithCount(count float64) []*dto.Metric {
 // newMetrics creates new metrics with the provided values.
 func (s *NethealthSuite) newMetrics(nodeValue, peerValue string, count float64) []*dto.Metric {
 	peer := peerLabel
-	node := nodeLabel
 
 	return []*dto.Metric{
 		&dto.Metric{
 			Label: []*dto.LabelPair{
 				&dto.LabelPair{Name: &peer, Value: &peerValue},
-				&dto.LabelPair{Name: &node, Value: &nodeValue},
 			},
 			Counter: &dto.Counter{Value: &count},
 		},

--- a/monitoring/nethealth_test.go
+++ b/monitoring/nethealth_test.go
@@ -242,7 +242,7 @@ func (s *NethealthSuite) TestParseMetricsFailure(c *C) {
 	}{
 		{
 			comment:  Commentf("Expected missing request metrics error."),
-			expected: fmt.Sprintf("%s metrics not found, failed to parse echo requests", echoRequestLabel),
+			expected: fmt.Sprintf("failed to parse echo requests\n\t%s metrics not found", echoRequestLabel),
 			metrics: `# HELP nethealth_echo_timeout_total The number of echo requests that have timed out
 	      # TYPE nethealth_echo_timeout_total counter
 	      nethealth_echo_timeout_total{node_name="10.128.0.96",peer_name="10.128.0.70"} 37
@@ -251,7 +251,7 @@ func (s *NethealthSuite) TestParseMetricsFailure(c *C) {
 		},
 		{
 			comment:  Commentf("Expected missing timeout metrics error."),
-			expected: fmt.Sprintf("%s metrics not found, failed to parse echo timeouts", echoTimeoutLabel),
+			expected: fmt.Sprintf("failed to parse echo timeouts\n\t%s metrics not found", echoTimeoutLabel),
 			metrics: `# HELP nethealth_echo_request_total The number of echo requests that have been sent
 	      # TYPE nethealth_echo_request_total counter
 	      nethealth_echo_request_total{node_name="10.128.0.96",peer_name="10.128.0.70"} 236
@@ -259,8 +259,9 @@ func (s *NethealthSuite) TestParseMetricsFailure(c *C) {
 		  `,
 		},
 		{
-			comment:  Commentf("Expected error about unequal counters."),
-			expected: "expected equal number of counters for requests and timeouts,but received 2 request counters and 1 timeout counters",
+			comment: Commentf("Expected error about unequal counters."),
+			expected: "received incomplete pair(s) of nethealth metrics. " +
+				"This may be due to a bug in prometheus or in the way nethealth is exposing its metrics",
 			metrics: `# HELP nethealth_echo_request_total The number of echo requests that have been sent
 	      # TYPE nethealth_echo_request_total counter
 	      nethealth_echo_request_total{node_name="10.128.0.96",peer_name="10.128.0.70"} 236

--- a/monitoring/nethealth_test.go
+++ b/monitoring/nethealth_test.go
@@ -167,7 +167,7 @@ func (s *NethealthSuite) TestNethealthVerification(c *C) {
 		},
 		{
 			comment:  Commentf("Expected failed probe. Timeouts increase at each interval."),
-			expected: &health.Probes{NewProbeFromErr(nethealthCheckerID, nethealthDetail(testNode), nil)},
+			expected: &health.Probes{nethealthFailureProbe(nethealthCheckerID, testNode, abovePLT)},
 			storedData: peerData{
 				packetLoss: s.newPacketLoss(abovePLT, abovePLT, abovePLT, abovePLT, abovePLT),
 			},
@@ -223,10 +223,7 @@ func (s *NethealthSuite) TestParseMetricsSuccess(c *C) {
 	for _, testCase := range testCases {
 		testCase := testCase
 
-		metricFamilies, err := s.textToMetrics(testCase.metrics)
-		c.Assert(err, IsNil, testCase.comment)
-
-		netData, err := parseMetrics(metricFamilies)
+		netData, err := parseMetrics([]byte(testCase.metrics))
 		c.Assert(err, IsNil, testCase.comment)
 		c.Assert(netData, test.DeepCompare, testCase.expected)
 	}
@@ -287,10 +284,7 @@ func (s *NethealthSuite) TestParseMetricsFailure(c *C) {
 	for _, testCase := range testCases {
 		testCase := testCase
 
-		metricFamilies, err := s.textToMetrics(testCase.metrics)
-		c.Assert(err, IsNil, testCase.comment)
-
-		_, err = parseMetrics(metricFamilies)
+		_, err := parseMetrics([]byte(testCase.metrics))
 		c.Assert(err.Error(), Equals, testCase.expected, testCase.comment)
 	}
 }

--- a/monitoring/nethealth_test.go
+++ b/monitoring/nethealth_test.go
@@ -119,9 +119,7 @@ func (s *NethealthSuite) TestUpdateTimeoutStats(c *C) {
 
 	for _, testCase := range testCases {
 		testCase := testCase
-
-		checker, err := s.newNethealthChecker()
-		c.Assert(err, IsNil)
+		checker := s.newNethealthChecker()
 
 		for _, data := range testCase.incomingData {
 			c.Assert(checker.updatePeer(testNode, data), IsNil, testCase.comment)
@@ -184,8 +182,7 @@ func (s *NethealthSuite) TestNethealthVerification(c *C) {
 		},
 	}
 
-	checker, err := s.newNethealthChecker()
-	c.Assert(err, IsNil)
+	checker := s.newNethealthChecker()
 
 	for _, testCase := range testCases {
 		testCase := testCase
@@ -199,21 +196,11 @@ func (s *NethealthSuite) TestNethealthVerification(c *C) {
 }
 
 // newNethealthChecker returns a new nethealth checker to be used for testing.
-func (s *NethealthSuite) newNethealthChecker() (*nethealthChecker, error) {
+func (s *NethealthSuite) newNethealthChecker() *nethealthChecker {
 	return &nethealthChecker{
 		peerStats:      newNetStats(netStatsCapacity),
 		seriesCapacity: testCapacity,
-	}, nil
-}
-
-// newNetData wraps the counters into networkData and maps it to the test node.
-func (s *NethealthSuite) newNetData(requestTotal, timeoutTotal float64) map[string]networkData {
-	data := make(map[string]networkData)
-	data[testNode] = networkData{
-		requestTotal: requestTotal,
-		timeoutTotal: timeoutTotal,
 	}
-	return data
 }
 
 const (

--- a/monitoring/nethealth_test.go
+++ b/monitoring/nethealth_test.go
@@ -76,17 +76,17 @@ func (s *NethealthSuite) TestNethealthVerification(c *C) {
 	}{
 		{
 			comment:  Commentf("Expected no failed probes. Not enough data points."),
-			expected: &health.Probes{},
+			expected: new(health.Probes),
 			data:     []int64{0, 1, 2},
 		},
 		{
 			comment:  Commentf("Expected no failed probes. No timeouts."),
-			expected: &health.Probes{},
+			expected: new(health.Probes),
 			data:     []int64{0, 0, 0, 0, 0},
 		},
 		{
 			comment:  Commentf("Expected no failed probes. Timeouts do not increase for a long enough duration"),
-			expected: &health.Probes{},
+			expected: new(health.Probes),
 			data:     []int64{0, 1, 2, 3, 3},
 		},
 		{
@@ -101,10 +101,11 @@ func (s *NethealthSuite) TestNethealthVerification(c *C) {
 
 	for _, testCase := range testCases {
 		testCase := testCase
-		reporter := &health.Probes{}
 
 		c.Assert(checker.setTimeoutSeries(testNode, testCase.data), IsNil, testCase.comment)
-		c.Assert(checker.verifyNethealth([]string{testNode}, reporter), IsNil, testCase.comment)
+
+		reporter, err := checker.verifyNethealth([]string{testNode})
+		c.Assert(err, IsNil, testCase.comment)
 		c.Assert(reporter, test.DeepCompare, testCase.expected, testCase.comment)
 	}
 }

--- a/monitoring/nethealth_test.go
+++ b/monitoring/nethealth_test.go
@@ -17,8 +17,14 @@ limitations under the License.
 package monitoring
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/gravitational/satellite/agent/health"
 	"github.com/gravitational/satellite/lib/test"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
 	. "gopkg.in/check.v1"
 )
 
@@ -37,58 +43,50 @@ func (s *NethealthSuite) TestUpdateTimeoutStats(c *C) {
 		{
 			comment: Commentf("Expected no data points to be recorded. Requests did not increase."),
 			expected: peerData{
-				prevRequestTotal: 0,
-				prevTimeoutTotal: 0,
-				requestInc:       nil,
-				timeoutInc:       nil,
+				packetLoss: s.newPacketLoss(),
 			},
 			incomingData: []networkData{
-				networkData{requestTotal: 0, timeoutTotal: 0},
-				networkData{requestTotal: 0, timeoutTotal: 0},
-				networkData{requestTotal: 0, timeoutTotal: 0},
-				networkData{requestTotal: 0, timeoutTotal: 0},
-				networkData{requestTotal: 0, timeoutTotal: 0},
+				networkData{},
+				networkData{},
+				networkData{},
+				networkData{},
+				networkData{},
 			},
 		},
 		{
 			comment: Commentf("Expected no data points to be recorded. Timeout inc > request inc"),
 			expected: peerData{
-				prevRequestTotal: 0,
 				prevTimeoutTotal: 5,
-				requestInc:       nil,
-				timeoutInc:       nil,
+				packetLoss:       s.newPacketLoss(),
 			},
 			incomingData: []networkData{
-				networkData{requestTotal: 0, timeoutTotal: 1},
-				networkData{requestTotal: 0, timeoutTotal: 2},
-				networkData{requestTotal: 0, timeoutTotal: 3},
-				networkData{requestTotal: 0, timeoutTotal: 4},
-				networkData{requestTotal: 0, timeoutTotal: 5},
+				networkData{timeoutTotal: 1},
+				networkData{timeoutTotal: 2},
+				networkData{timeoutTotal: 3},
+				networkData{timeoutTotal: 4},
+				networkData{timeoutTotal: 5},
 			},
 		},
 		{
 			comment: Commentf("Expected zero packet loss to be recorded."),
 			expected: peerData{
 				prevRequestTotal: 5,
-				prevTimeoutTotal: 0,
-				requestInc:       []float64{1, 1, 1, 1, 1},
-				timeoutInc:       []float64{0, 0, 0, 0, 0},
+				packetLoss:       s.newPacketLoss(0, 0, 0, 0, 0),
 			},
 			incomingData: []networkData{
-				networkData{requestTotal: 1, timeoutTotal: 0},
-				networkData{requestTotal: 2, timeoutTotal: 0},
-				networkData{requestTotal: 3, timeoutTotal: 0},
-				networkData{requestTotal: 4, timeoutTotal: 0},
-				networkData{requestTotal: 5, timeoutTotal: 0},
+				networkData{requestTotal: 1},
+				networkData{requestTotal: 2},
+				networkData{requestTotal: 3},
+				networkData{requestTotal: 4},
+				networkData{requestTotal: 5},
 			},
 		},
 		{
-			comment: Commentf("Expected 100% packet loss to be recorded."),
+			comment: Commentf("Expected 100%% packet loss to be recorded."),
 			expected: peerData{
 				prevRequestTotal: 5,
 				prevTimeoutTotal: 5,
-				requestInc:       []float64{1, 1, 1, 1, 1},
-				timeoutInc:       []float64{1, 1, 1, 1, 1},
+				packetLoss:       s.newPacketLoss(1, 1, 1, 1, 1),
 			},
 			incomingData: []networkData{
 				networkData{requestTotal: 1, timeoutTotal: 1},
@@ -101,10 +99,9 @@ func (s *NethealthSuite) TestUpdateTimeoutStats(c *C) {
 		{
 			comment: Commentf("Expected oldest data point to be removed"),
 			expected: peerData{
-				prevRequestTotal: 7,
-				prevTimeoutTotal: 2,
-				requestInc:       []float64{1, 1, 1, 1, 2},
-				timeoutInc:       []float64{0, 0, 0, 0, 1},
+				prevRequestTotal: 6,
+				prevTimeoutTotal: 1,
+				packetLoss:       s.newPacketLoss(0, 0, 0, 0, 0),
 			},
 			incomingData: []networkData{
 				networkData{requestTotal: 1, timeoutTotal: 1},
@@ -112,7 +109,7 @@ func (s *NethealthSuite) TestUpdateTimeoutStats(c *C) {
 				networkData{requestTotal: 3, timeoutTotal: 1},
 				networkData{requestTotal: 4, timeoutTotal: 1},
 				networkData{requestTotal: 5, timeoutTotal: 1},
-				networkData{requestTotal: 7, timeoutTotal: 2},
+				networkData{requestTotal: 6, timeoutTotal: 1},
 			},
 		},
 	}
@@ -144,40 +141,35 @@ func (s *NethealthSuite) TestNethealthVerification(c *C) {
 			comment:  Commentf("Expected no failed probes. Not enough data points."),
 			expected: new(health.Probes),
 			storedData: peerData{
-				requestInc: []float64{10, 20, 30},
-				timeoutInc: []float64{5, 10, 15},
+				packetLoss: s.newPacketLoss(1, 1, 1),
 			},
 		},
 		{
 			comment:  Commentf("Expected no failed probes. No timeouts."),
 			expected: new(health.Probes),
 			storedData: peerData{
-				requestInc: []float64{10, 20, 30, 40, 50},
-				timeoutInc: []float64{0, 0, 0, 0, 0},
+				packetLoss: s.newPacketLoss(0, 0, 0, 0, 0),
 			},
 		},
 		{
 			comment:  Commentf("Expected no failed probes. Data points do not exceed threshold."),
 			expected: new(health.Probes),
 			storedData: peerData{
-				requestInc: []float64{10, 20, 30, 40, 50},
-				timeoutInc: []float64{2, 4, 6, 8, 10},
+				packetLoss: s.newPacketLoss(plt, plt, plt, plt, plt),
 			},
 		},
 		{
 			comment:  Commentf("Expected no failed probes. Does not exceed threshold throughout entire interval."),
 			expected: new(health.Probes),
 			storedData: peerData{
-				requestInc: []float64{10, 20, 30, 40, 50},
-				timeoutInc: []float64{10, 20, 30, 40, 0},
+				packetLoss: s.newPacketLoss(abovePLT, abovePLT, abovePLT, abovePLT, 0),
 			},
 		},
 		{
 			comment:  Commentf("Expected failed probe. Timeouts increase at each interval."),
 			expected: &health.Probes{NewProbeFromErr(nethealthCheckerID, nethealthDetail(testNode), nil)},
 			storedData: peerData{
-				requestInc: []float64{10, 20, 30, 40, 50},
-				timeoutInc: []float64{10, 20, 30, 40, 50},
+				packetLoss: s.newPacketLoss(abovePLT, abovePLT, abovePLT, abovePLT, abovePLT),
 			},
 		},
 	}
@@ -195,17 +187,141 @@ func (s *NethealthSuite) TestNethealthVerification(c *C) {
 	}
 }
 
+// TestParseMetricsSuccess verifies parseMetrics can successfully parse
+// nethealth metrics.
+func (s *NethealthSuite) TestParseMetricsSuccess(c *C) {
+	var testCases = []struct {
+		comment  CommentInterface
+		expected map[string]networkData
+		metrics  string
+	}{
+
+		{
+			comment: Commentf("Expected networkData for peers 10.128.0.70 and 10.128.0.97."),
+			expected: map[string]networkData{
+				"10.128.0.70": networkData{
+					requestTotal: 236,
+					timeoutTotal: 37,
+				},
+				"10.128.0.97": networkData{
+					requestTotal: 273,
+					timeoutTotal: 0,
+				},
+			},
+			metrics: `# HELP nethealth_echo_request_total The number of echo requests that have been sent
+	      # TYPE nethealth_echo_request_total counter
+	      nethealth_echo_request_total{node_name="10.128.0.96",peer_name="10.128.0.70"} 236
+	      nethealth_echo_request_total{node_name="10.128.0.96",peer_name="10.128.0.97"} 273
+	      # HELP nethealth_echo_timeout_total The number of echo requests that have timed out
+	      # TYPE nethealth_echo_timeout_total counter
+	      nethealth_echo_timeout_total{node_name="10.128.0.96",peer_name="10.128.0.70"} 37
+		  nethealth_echo_timeout_total{node_name="10.128.0.96",peer_name="10.128.0.97"} 0
+		  `,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		metricFamilies, err := s.textToMetrics(testCase.metrics)
+		c.Assert(err, IsNil, testCase.comment)
+
+		netData, err := parseMetrics(metricFamilies)
+		c.Assert(err, IsNil, testCase.comment)
+		c.Assert(netData, test.DeepCompare, testCase.expected)
+	}
+}
+
+// TestParseMetricsFailure verifies parseMetrics correctly handles invalid
+// metrics input.
+func (s *NethealthSuite) TestParseMetricsFailure(c *C) {
+	var testCases = []struct {
+		comment  CommentInterface
+		expected string
+		metrics  string
+	}{
+		{
+			comment:  Commentf("Expected missing request metrics error."),
+			expected: fmt.Sprintf("%s metrics not found, failed to parse echo requests", echoRequestLabel),
+			metrics: `# HELP nethealth_echo_timeout_total The number of echo requests that have timed out
+	      # TYPE nethealth_echo_timeout_total counter
+	      nethealth_echo_timeout_total{node_name="10.128.0.96",peer_name="10.128.0.70"} 37
+		  nethealth_echo_timeout_total{node_name="10.128.0.96",peer_name="10.128.0.97"} 0
+		  `,
+		},
+		{
+			comment:  Commentf("Expected missing timeout metrics error."),
+			expected: fmt.Sprintf("%s metrics not found, failed to parse echo timeouts", echoTimeoutLabel),
+			metrics: `# HELP nethealth_echo_request_total The number of echo requests that have been sent
+	      # TYPE nethealth_echo_request_total counter
+	      nethealth_echo_request_total{node_name="10.128.0.96",peer_name="10.128.0.70"} 236
+	      nethealth_echo_request_total{node_name="10.128.0.96",peer_name="10.128.0.97"} 273
+		  `,
+		},
+		{
+			comment:  Commentf("Expected error about unequal counters."),
+			expected: "expected equal number of counters for requests and timeouts,but received 2 request counters and 1 timeout counters",
+			metrics: `# HELP nethealth_echo_request_total The number of echo requests that have been sent
+	      # TYPE nethealth_echo_request_total counter
+	      nethealth_echo_request_total{node_name="10.128.0.96",peer_name="10.128.0.70"} 236
+	      nethealth_echo_request_total{node_name="10.128.0.96",peer_name="10.128.0.97"} 273
+		  # HELP nethealth_echo_timeout_total The number of echo requests that have timed out
+	      # TYPE nethealth_echo_timeout_total counter
+	      nethealth_echo_timeout_total{node_name="10.128.0.96",peer_name="10.128.0.70"} 37
+		  `,
+		},
+		{
+			comment:  Commentf("Expected error about missing timeout counter."),
+			expected: "echo timeout data not available for 10.128.0.97",
+			metrics: `# HELP nethealth_echo_request_total The number of echo requests that have been sent
+	      # TYPE nethealth_echo_request_total counter
+	      nethealth_echo_request_total{node_name="10.128.0.96",peer_name="10.128.0.97"} 273
+		  # HELP nethealth_echo_timeout_total The number of echo requests that have timed out
+	      # TYPE nethealth_echo_timeout_total counter
+	      nethealth_echo_timeout_total{node_name="10.128.0.96",peer_name="10.128.0.70"} 37
+		  `,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		metricFamilies, err := s.textToMetrics(testCase.metrics)
+		c.Assert(err, IsNil, testCase.comment)
+
+		_, err = parseMetrics(metricFamilies)
+		c.Assert(err.Error(), Equals, testCase.expected, testCase.comment)
+	}
+}
+
 // newNethealthChecker returns a new nethealth checker to be used for testing.
 func (s *NethealthSuite) newNethealthChecker() *nethealthChecker {
 	return &nethealthChecker{
-		peerStats:      newNetStats(netStatsCapacity),
-		seriesCapacity: testCapacity,
+		peerStats: newNetStats(netStatsCapacity, testCapacity),
 	}
+}
+
+// newPacketLoss constructs a new slice with capacity equal to testCapacity.
+// Provided packetLoss values are appended to the new slice.
+func (s *NethealthSuite) newPacketLoss(values ...float64) []float64 {
+	packetLoss := make([]float64, 0, testCapacity)
+	packetLoss = append(packetLoss, values...)
+	return packetLoss
+}
+
+// textToMetrics converts the string into a map of MetricFamilies.
+func (s *NethealthSuite) textToMetrics(metrics string) (map[string]*dto.MetricFamily, error) {
+	var parser expfmt.TextParser
+	return parser.TextToMetricFamilies(strings.NewReader(metrics))
 }
 
 const (
 	// testNode is used for 'node_name' or 'peer_name' value in test cases.
 	testNode = "test-node"
-	// testCapacity specifies the time series capacity used for test cases.
+	// testCapacity specifies the packetLoss capacity to use in test cases.
 	testCapacity = 5
+	// plt is alias for packetLossThreshold
+	plt = packetLossThreshold
+	// abovePLT is arbitrary value above packetLossThreshold
+	abovePLT = packetLossThreshold + .01
 )

--- a/monitoring/nethealth_test.go
+++ b/monitoring/nethealth_test.go
@@ -171,7 +171,7 @@ func (s *NethealthSuite) TestNethealthVerification(c *C) {
 			expected: new(health.Probes),
 			storedData: peerData{
 				requestInc: []float64{10, 20, 30, 40, 50},
-				timeoutInc: []float64{10, 0, 0, 0, 0},
+				timeoutInc: []float64{10, 20, 30, 40, 0},
 			},
 		},
 		{

--- a/monitoring/nethealth_test.go
+++ b/monitoring/nethealth_test.go
@@ -19,6 +19,7 @@ package monitoring
 import (
 	"github.com/gravitational/satellite/lib/test"
 
+	"github.com/mailgun/holster"
 	dto "github.com/prometheus/client_model/go"
 	. "gopkg.in/check.v1"
 )
@@ -108,20 +109,22 @@ func (s *NethealthSuite) TestNethealthVerification(c *C) {
 // newNethealthChecker returns a new nethealth checker to be used for testing.
 func (s *NethealthSuite) newNethealthChecker() (*nethealthChecker, error) {
 	config := NethealthConfig{
-		NodeName:       testNode,
-		NethealthName:  "mock-service-addr",
 		SeriesCapacity: testCapacity,
 	}
-	return NewNethealthChecker(config)
+
+	return &nethealthChecker{
+		timeoutStats:    holster.NewTTLMap(testCapacity),
+		NethealthConfig: config,
+	}, nil
 }
 
-// netMetricsWithCount creates new metrics with the provided count.
+// newMetricsWithCount creates new metrics with the provided count.
 func (s *NethealthSuite) newMetricsWithCount(count float64) []*dto.Metric {
-	return s.newMetrics(testNode, testNode, count)
+	return s.newMetrics(testNode, count)
 }
 
 // newMetrics creates new metrics with the provided values.
-func (s *NethealthSuite) newMetrics(nodeValue, peerValue string, count float64) []*dto.Metric {
+func (s *NethealthSuite) newMetrics(peerValue string, count float64) []*dto.Metric {
 	peer := peerLabel
 
 	return []*dto.Metric{

--- a/monitoring/os_linux_test.go
+++ b/monitoring/os_linux_test.go
@@ -84,7 +84,7 @@ func (*MonitoringSuite) TestValidatesOS(c *C) {
 			probes: health.Probes{
 				prober.newRaisedProbe(probe{
 					detail: "failed to validate OS distribution",
-					error:  "permission denied, failed to query OS version",
+					error:  "failed to query OS version\n\tpermission denied",
 				}),
 			},
 			comment: "fail if error prevents from reading the file (other than not found)",

--- a/monitoring/timedrift.go
+++ b/monitoring/timedrift.go
@@ -31,7 +31,6 @@ import (
 	"github.com/gravitational/trace"
 	serf "github.com/hashicorp/serf/client"
 	"github.com/jonboulle/clockwork"
-	"github.com/mailgun/holster"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -41,11 +40,6 @@ const (
 	// timeDriftThreshold sets the default threshold of the acceptable time
 	// difference between nodes.
 	timeDriftThreshold = 300 * time.Millisecond
-	// clientsCacheCapacity is the capacity of the TTL map that holds
-	// clients to satellite agents on other cluster nodes.
-	clientsCacheCapacity = 1000
-	// clientCacheTTLSeconds specifies how long clients information will be kept before being dropped
-	clientsCacheTTLSeconds = 3600 // 1 hour
 )
 
 // timeDriftChecker is a checker that verifies that the time difference between
@@ -58,7 +52,7 @@ type timeDriftChecker struct {
 	// mu protects the clients map.
 	mu sync.Mutex
 	// clients contains RPC clients for other cluster nodes.
-	clients *holster.TTLMap
+	clients map[string]client.Client
 }
 
 // TimeDriftCheckerConfig stores configuration for the time drift check.
@@ -110,13 +104,10 @@ func NewTimeDriftChecker(conf TimeDriftCheckerConfig) (c health.Checker, err err
 	if err := conf.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	clientsCache := holster.NewTTLMap(clientsCacheCapacity)
-
 	return &timeDriftChecker{
 		TimeDriftCheckerConfig: conf,
 		FieldLogger:            log.WithField(trace.Component, timeDriftCheckerID),
-		clients:                clientsCache,
+		clients:                make(map[string]client.Client),
 	}, nil
 }
 
@@ -253,12 +244,39 @@ func (c *timeDriftChecker) nodesToCheck() (result []serf.Member, err error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	c.removeExpiredClients(nodes)
+
 	for _, node := range nodes {
 		if c.shouldCheckNode(node) {
 			result = append(result, node)
 		}
 	}
 	return result, nil
+}
+
+// removeExpiredClients closes client connections to nodes that have left the
+// cluster and deletes the entry from the cache.
+func (c *timeDriftChecker) removeExpiredClients(members []serf.Member) {
+	currentMembers := make(map[string]struct{})
+	for _, member := range members {
+		currentMembers[member.Addr.String()] = struct{}{}
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for addr, conn := range c.clients {
+		if _, ok := currentMembers[addr]; ok {
+			continue
+		}
+		if err := conn.Close(); err != nil {
+			log.WithError(err).WithField("address", addr).Error("Failed to close client connection.")
+			continue
+		}
+		log.WithField("address", addr).Info("Closed client connection.")
+		delete(c.clients, addr)
+	}
 }
 
 // shouldCheckNode returns true if the check should be run against specified
@@ -271,19 +289,31 @@ func (c *timeDriftChecker) shouldCheckNode(node serf.Member) bool {
 // getAgentClient returns Satellite agent client for the provided node.
 func (c *timeDriftChecker) getAgentClient(ctx context.Context, node serf.Member) (client.Client, error) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	clientI, exists := c.clients.Get(node.Addr.String())
-	if exists {
-		return clientI.(client.Client), nil
+	if conn, exists := c.clients[node.Addr.String()]; exists {
+		c.mu.Unlock()
+		return conn, nil
 	}
-	client, err := c.DialRPC(ctx, &node)
+	c.mu.Unlock()
+
+	newConn, err := c.DialRPC(ctx, &node)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := c.clients.Set(node.Addr.String(), client, clientsCacheTTLSeconds); err != nil {
-		return nil, trace.Wrap(err)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Close newly created client connection if a new client was already cached while dialing.
+	if conn, exists := c.clients[node.Addr.String()]; exists {
+		if err := newConn.Close(); err != nil {
+			log.WithError(err).WithField("address", node.Addr.String()).Error("Failed to close client connection.")
+		}
+		return conn, nil
 	}
-	return client, nil
+
+	// Cache and return new client connection.
+	c.clients[node.Addr.String()] = newConn
+	return newConn, nil
 }
 
 // isDriftHigh returns true if the provided drift value is over the threshold.

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gravitational/trace"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ConvertError converts the err into a proper trace error.
+func ConvertError(err error) error {
+	return ConvertErrorWithContext(err, "")
+}
+
+// ConvertErrorWithContext converts the err into a proper trace error.
+func ConvertErrorWithContext(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	statusErr, ok := err.(*errors.StatusError)
+	if !ok {
+		return err
+	}
+
+	message := fmt.Sprintf("%v", err)
+	if !isEmptyDetails(statusErr.ErrStatus.Details) {
+		message = fmt.Sprintf("%v, details: %v", message, statusErr.ErrStatus.Details)
+	}
+	if format != "" {
+		message = fmt.Sprintf("%v: %v", fmt.Sprintf(format, args...), message)
+	}
+
+	status := statusErr.Status()
+	switch {
+	case status.Code == http.StatusConflict && status.Reason == metav1.StatusReasonAlreadyExists:
+		return trace.AlreadyExists(message)
+	case status.Code == http.StatusNotFound:
+		return trace.NotFound(message)
+	case status.Code == http.StatusForbidden:
+		return trace.AccessDenied(message)
+	}
+	return err
+}
+
+func isEmptyDetails(details *metav1.StatusDetails) bool {
+	if details == nil {
+		return true
+	}
+
+	if details.Name == "" && details.Group == "" && details.Kind == "" && len(details.Causes) == 0 {
+		return true
+	}
+	return false
+}

--- a/vendor/github.com/gravitational/trace/errors.go
+++ b/vendor/github.com/gravitational/trace/errors.go
@@ -56,16 +56,15 @@ func (e *NotFoundError) OrigError() error {
 }
 
 // IsNotFound returns whether this error is of NotFoundError type
-func IsNotFound(e error) bool {
-	type nf interface {
+func IsNotFound(err error) bool {
+	err = Unwrap(err)
+	_, ok := err.(interface {
 		IsNotFoundError() bool
-	}
-	err := Unwrap(e)
-	_, ok := err.(nf)
+	})
 	if !ok {
 		return os.IsNotExist(err)
 	}
-	return ok
+	return true
 }
 
 // AlreadyExists returns a new instance of AlreadyExists error
@@ -252,11 +251,10 @@ func (e *AccessDeniedError) OrigError() error {
 }
 
 // IsAccessDenied detects if this error is of AccessDeniedError type
-func IsAccessDenied(e error) bool {
-	type ad interface {
+func IsAccessDenied(err error) bool {
+	_, ok := Unwrap(err).(interface {
 		IsAccessDeniedError() bool
-	}
-	_, ok := Unwrap(e).(ad)
+	})
 	return ok
 }
 
@@ -285,7 +283,7 @@ func ConvertSystemError(err error) error {
 			Message: message,
 		}, message)
 	case x509.SystemRootsError, x509.UnknownAuthorityError:
-		return wrapWithDepth(&TrustError{Err: innerError}, 2)
+		return newTrace(&TrustError{Err: innerError}, 2)
 	}
 	if _, ok := innerError.(net.Error); ok {
 		return WrapWithMessage(&ConnectionProblemError{

--- a/vendor/github.com/gravitational/trace/httplib.go
+++ b/vendor/github.com/gravitational/trace/httplib.go
@@ -8,19 +8,21 @@ import (
 
 // WriteError sets up HTTP error response and writes it to writer w
 func WriteError(w http.ResponseWriter, err error) {
-	if IsAggregate(err) {
-		for i := 0; i < maxHops; i++ {
-			var aggErr Aggregate
-			var ok bool
-			if aggErr, ok = Unwrap(err).(Aggregate); !ok {
-				break
-			}
-			errors := aggErr.Errors()
-			if len(errors) == 0 {
-				break
-			}
-			err = errors[0]
+	if !IsAggregate(err) {
+		replyJSON(w, ErrorToCode(err), err)
+		return
+	}
+	for i := 0; i < maxHops; i++ {
+		var aggErr Aggregate
+		var ok bool
+		if aggErr, ok = Unwrap(err).(Aggregate); !ok {
+			break
 		}
+		errors := aggErr.Errors()
+		if len(errors) == 0 {
+			break
+		}
+		err = errors[0]
 	}
 	replyJSON(w, ErrorToCode(err), err)
 }
@@ -54,61 +56,58 @@ func ErrorToCode(err error) int {
 // ReadError converts http error to internal error type
 // based on HTTP response code and HTTP body contents
 // if status code does not indicate error, it will return nil
-func ReadError(statusCode int, re []byte) error {
-	var e error
-	switch statusCode {
-	case http.StatusNotFound:
-		e = &NotFoundError{Message: string(re)}
-	case http.StatusBadRequest:
-		e = &BadParameterError{Message: string(re)}
-	case http.StatusNotImplemented:
-		e = &NotImplementedError{Message: string(re)}
-	case http.StatusPreconditionFailed:
-		e = &CompareFailedError{Message: string(re)}
-	case http.StatusForbidden:
-		e = &AccessDeniedError{Message: string(re)}
-	case http.StatusConflict:
-		e = &AlreadyExistsError{Message: string(re)}
-	case http.StatusTooManyRequests:
-		e = &LimitExceededError{Message: string(re)}
-	case http.StatusGatewayTimeout:
-		e = &ConnectionProblemError{Message: string(re)}
-	default:
-		if statusCode < 200 || statusCode >= 400 {
-			return Errorf(string(re))
-		}
+func ReadError(statusCode int, respBytes []byte) error {
+	if statusCode >= http.StatusOK && statusCode < http.StatusBadRequest {
 		return nil
 	}
-	return unmarshalError(e, re)
+	var err error
+	switch statusCode {
+	case http.StatusNotFound:
+		err = &NotFoundError{}
+	case http.StatusBadRequest:
+		err = &BadParameterError{}
+	case http.StatusNotImplemented:
+		err = &NotImplementedError{}
+	case http.StatusPreconditionFailed:
+		err = &CompareFailedError{}
+	case http.StatusForbidden:
+		err = &AccessDeniedError{}
+	case http.StatusConflict:
+		err = &AlreadyExistsError{}
+	case http.StatusTooManyRequests:
+		err = &LimitExceededError{}
+	case http.StatusGatewayTimeout:
+		err = &ConnectionProblemError{}
+	default:
+		err = &externalError{}
+	}
+	return wrapProxy(unmarshalError(err, respBytes))
 }
 
 func replyJSON(w http.ResponseWriter, code int, err error) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-
 	var out []byte
-	if IsDebug() {
-		// trace error can marshal itself,
-		// otherwise capture error message and marshal it explicitly
-		var obj interface{} = err
-		if _, ok := err.(*TraceErr); !ok {
-			obj = message{Message: err.Error()}
-		}
-		out, err = json.MarshalIndent(obj, "", "    ")
-		if err != nil {
-			out = []byte(fmt.Sprintf(`{"message": "internal marshal error: %v"}`, err))
-		}
-	} else {
-		innerError := err
-		if terr, ok := err.(Error); ok {
-			innerError = terr.OrigError()
-		}
-		out, err = json.Marshal(message{Message: innerError.Error()})
+	// trace error can marshal itself,
+	// otherwise capture error message and marshal it explicitly
+	var obj interface{} = err
+	if _, ok := err.(*TraceErr); !ok {
+		obj = externalError{Message: err.Error()}
+	}
+	out, err = json.MarshalIndent(obj, "", "    ")
+	if err != nil {
+		out = []byte(fmt.Sprintf(`{"message": "internal marshal error: %v"}`, err))
 	}
 	w.Write(out)
 }
 
-type message struct {
+// Error returns the underlying message
+func (r *externalError) Error() string {
+	return r.Message
+}
+
+type externalError struct {
+	// Message specifies the error message
 	Message string `json:"message"`
 }
 

--- a/vendor/github.com/gravitational/trace/trace.go
+++ b/vendor/github.com/gravitational/trace/trace.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 Gravitational, Inc.
+Copyright 2015-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ func SetDebug(enabled bool) {
 	}
 }
 
-// IsDebug returns true if debug mode is on, false otherwise
+// IsDebug returns true if debug mode is on
 func IsDebug() bool {
 	return atomic.LoadInt32(&debug) == 1
 }
@@ -50,20 +50,38 @@ func IsDebug() bool {
 // Wrap takes the original error and wraps it into the Trace struct
 // memorizing the context of the error.
 func Wrap(err error, args ...interface{}) Error {
+	if err == nil {
+		return nil
+	}
 	if len(args) > 0 {
 		format := args[0]
 		args = args[1:]
 		return WrapWithMessage(err, format, args...)
 	}
-	return wrapWithDepth(err, 2)
+	if traceErr, ok := err.(Error); ok {
+		return traceErr
+	}
+	return newTrace(err, 2)
 }
 
-// Unwrap unwraps error to it's original error
+// Unwrap returns the original error the given error wraps
 func Unwrap(err error) error {
-	if terr, ok := err.(Error); ok {
-		return terr.OrigError()
+	if err, ok := err.(ErrorWrapper); ok {
+		return err.OrigError()
 	}
 	return err
+}
+
+// ErrorWrapper wraps another error
+type ErrorWrapper interface {
+	// OrigError returns the wrapped error
+	OrigError() error
+}
+
+// DebugReporter formats an error for display
+type DebugReporter interface {
+	// DebugReport formats an error for display
+	DebugReport() string
 }
 
 // UserMessage returns user-friendly part of the error
@@ -102,8 +120,8 @@ func DebugReport(err error) string {
 	if err == nil {
 		return ""
 	}
-	if wrap, ok := err.(Error); ok {
-		return wrap.DebugReport()
+	if reporter, ok := err.(DebugReporter); ok {
+		return reporter.DebugReport()
 	}
 	return err.Error()
 }
@@ -121,24 +139,13 @@ func GetFields(err error) map[string]interface{} {
 
 // WrapWithMessage wraps the original error into Error and adds user message if any
 func WrapWithMessage(err error, message interface{}, args ...interface{}) Error {
-	trace := wrapWithDepth(err, 3)
-	if trace != nil {
-		trace.AddUserMessage(message, args...)
-	}
-	return trace
-}
-
-func wrapWithDepth(err error, depth int) Error {
-	if err == nil {
-		return nil
-	}
 	var trace Error
-	if wrapped, ok := err.(Error); ok {
-		trace = wrapped
+	if traceErr, ok := err.(Error); ok {
+		trace = traceErr
 	} else {
-		trace = newTrace(depth+1, err)
+		trace = newTrace(err, 3)
 	}
-
+	trace.AddUserMessage(message, args...)
 	return trace
 }
 
@@ -147,7 +154,7 @@ func wrapWithDepth(err error, depth int) Error {
 // callee, line number and function that simplifies debugging
 func Errorf(format string, args ...interface{}) (err error) {
 	err = fmt.Errorf(format, args...)
-	trace := wrapWithDepth(err, 2)
+	trace := newTrace(err, 2)
 	trace.AddUserMessage(format, args...)
 	return trace
 }
@@ -162,7 +169,7 @@ func Fatalf(format string, args ...interface{}) error {
 	}
 }
 
-func newTrace(depth int, err error) *TraceErr {
+func newTrace(err error, depth int) *TraceErr {
 	var buf [32]uintptr
 	n := runtime.Callers(depth+1, buf[:])
 	pcs := buf[:n]
@@ -279,6 +286,17 @@ func (t *Trace) String() string {
 	return fmt.Sprintf("%v:%v", file, t.Line)
 }
 
+// MarshalJSON marshals this error as JSON-encoded payload
+func (r *TraceErr) MarshalJSON() ([]byte, error) {
+	if r == nil {
+		return nil, nil
+	}
+	type marshalableError TraceErr
+	err := marshalableError(*r)
+	err.Err = &externalError{Message: r.Err.Error()}
+	return json.Marshal(err)
+}
+
 // TraceErr contains error message and some additional
 // information about the error origin
 type TraceErr struct {
@@ -286,29 +304,38 @@ type TraceErr struct {
 	Err error `json:"error"`
 	// Traces is a slice of stack trace entries for the error
 	Traces `json:"traces"`
-	// Message is an optional message that can be wrapped with the original error
+	// Message is an optional message that can be wrapped with the original error.
+	//
+	// This field is obsolete, replaced by messages list below.
 	Message string `json:"message,omitempty"`
+	// Messages is a list of user messages added to this error.
+	Messages []string `json:"messages,omitempty"`
 	// Fields is a list of key-value-pairs that can be wrapped with the error to give additional context
-	Fields map[string]interface{} `json:"fields,omitempty`
+	Fields map[string]interface{} `json:"fields,omitempty"`
 }
 
 // Fields maps arbitrary keys to values inside an error
 type Fields map[string]interface{}
 
+// RawTrace describes the error trace on the wire
 type RawTrace struct {
-	Err     json.RawMessage `json:"error"`
-	Traces  `json:"traces"`
+	// Err specifies the original error
+	Err json.RawMessage `json:"error,omitempty"`
+	// Traces lists the stack traces at the moment the error was recorded
+	Traces `json:"traces,omitempty"`
+	// Message specifies the optional user-facing message
 	Message string `json:"message"`
+	// Messages is a list of user messages added to this error.
+	Messages []string `json:"messages"`
+	// Fields is a list of key-value-pairs that can be wrapped with the error to give additional context
+	Fields map[string]interface{} `json:"fields,omitempty"`
 }
 
 // AddUserMessage adds user-friendly message describing the error nature
-func (e *TraceErr) AddUserMessage(formatArg interface{}, rest ...interface{}) {
+func (e *TraceErr) AddUserMessage(formatArg interface{}, rest ...interface{}) *TraceErr {
 	newMessage := fmt.Sprintf(fmt.Sprintf("%v", formatArg), rest...)
-	if len(e.Message) == 0 {
-		e.Message = newMessage
-	} else {
-		e.Message = strings.Join([]string{e.Message, newMessage}, ", ")
-	}
+	e.Messages = append(e.Messages, newMessage)
+	return e
 }
 
 // AddFields adds the given map of fields to the error being reported
@@ -327,15 +354,24 @@ func (e *TraceErr) AddField(k string, v interface{}) *TraceErr {
 	if e.Fields == nil {
 		e.Fields = make(map[string]interface{}, 1)
 	}
-
 	e.Fields[k] = v
-
 	return e
 }
 
 // UserMessage returns user-friendly error message
 func (e *TraceErr) UserMessage() string {
+	if len(e.Messages) > 0 {
+		// Format all collected messages in the reverse order, with each error
+		// on its own line with appropriate indentation so they form a tree and
+		// it's easy to see the cause and effect.
+		result := e.Messages[len(e.Messages)-1]
+		for index, indent := len(e.Messages)-1, 1; index > 0; index, indent = index-1, indent+1 {
+			result = fmt.Sprintf("%v\n%v%v", result, strings.Repeat("\t", indent), e.Messages[index-1])
+		}
+		return result
+	}
 	if e.Message != "" {
+		// For backwards compatibility return the old user message if it's present.
 		return e.Message
 	}
 	return UserMessage(e.Err)
@@ -343,14 +379,8 @@ func (e *TraceErr) UserMessage() string {
 
 // DebugReport returns developer-friendly error report
 func (e *TraceErr) DebugReport() string {
-	var buffer bytes.Buffer
-	err := reportTemplate.Execute(&buffer, struct {
-		OrigErrType    string
-		OrigErrMessage string
-		Fields         map[string]interface{}
-		StackTrace     string
-		UserMessage    string
-	}{
+	var buf bytes.Buffer
+	err := reportTemplate.Execute(&buf, errorReport{
 		OrigErrType:    fmt.Sprintf("%T", e.Err),
 		OrigErrMessage: e.Err.Error(),
 		Fields:         e.Fields,
@@ -360,19 +390,8 @@ func (e *TraceErr) DebugReport() string {
 	if err != nil {
 		return fmt.Sprint("error generating debug report: ", err.Error())
 	}
-	return buffer.String()
+	return buf.String()
 }
-
-var reportTemplate = template.Must(template.New("debugReport").Parse(reportTemplateText))
-var reportTemplateText = `
-ERROR REPORT:
-Original Error: {{.OrigErrType}} {{.OrigErrMessage}}
-{{if .Fields}}Fields: 
-{{range $key, $value := .Fields}}  {{$key}}: {{$value}}
-{{end}}{{end}}Stack Trace:
-{{.StackTrace}}
-User Message: {{.UserMessage}}
-`
 
 // Error returns user-friendly error message when not in debug mode
 func (e *TraceErr) Error() string {
@@ -415,14 +434,15 @@ const maxHops = 50
 // So error handlers can use OrigError() to retrieve error from the wrapper
 type Error interface {
 	error
-	// OrigError returns original error wrapped in this error
-	OrigError() error
+	ErrorWrapper
+	DebugReporter
+
 	// AddMessage adds formatted user-facing message
 	// to the error, depends on the implementation,
 	// usually works as fmt.Sprintf(formatArg, rest...)
 	// but implementations can choose another way, e.g. treat
 	// arguments as structured args
-	AddUserMessage(formatArg interface{}, rest ...interface{})
+	AddUserMessage(formatArg interface{}, rest ...interface{}) *TraceErr
 
 	// AddField adds additional field information to the error
 	AddField(key string, value interface{}) *TraceErr
@@ -432,9 +452,6 @@ type Error interface {
 
 	// UserMessage returns user-friendly error message
 	UserMessage() string
-
-	// DebugReport returns developer-friendly error report
-	DebugReport() string
 
 	// GetFields returns any fields that have been added to the error
 	GetFields() map[string]interface{}
@@ -453,7 +470,7 @@ func NewAggregate(errs ...error) error {
 	if len(nonNils) == 0 {
 		return nil
 	}
-	return wrapWithDepth(aggregate(nonNils), 2)
+	return newTrace(aggregate(nonNils), 2)
 }
 
 // NewAggregateFromChannel creates a new aggregate instance from the provided
@@ -512,3 +529,80 @@ func IsAggregate(err error) bool {
 	_, ok := Unwrap(err).(Aggregate)
 	return ok
 }
+
+// wrapProxy wraps the specified error as a new error trace
+func wrapProxy(err error) Error {
+	if err == nil {
+		return nil
+	}
+	return proxyError{
+		// Do not include ReadError in the trace
+		TraceErr: newTrace(err, 3),
+	}
+}
+
+// DebugReport formats the underlying error for display
+// Implements DebugReporter
+func (r proxyError) DebugReport() string {
+	var wrappedErr *TraceErr
+	var ok bool
+	if wrappedErr, ok = r.TraceErr.Err.(*TraceErr); !ok {
+		return DebugReport(r.TraceErr)
+	}
+	var buf bytes.Buffer
+	//nolint:errcheck
+	reportTemplate.Execute(&buf, errorReport{
+		OrigErrType:    fmt.Sprintf("%T", wrappedErr.Err),
+		OrigErrMessage: wrappedErr.Err.Error(),
+		Fields:         wrappedErr.Fields,
+		StackTrace:     wrappedErr.Traces.String(),
+		UserMessage:    wrappedErr.UserMessage(),
+		Caught:         r.TraceErr.Traces.String(),
+	})
+	return buf.String()
+}
+
+// OrigError returns the original error.
+// Implements WrappingError
+func (r proxyError) OrigError() error {
+	return r.TraceErr.OrigError()
+}
+
+// Error returns the error message of the underlying error
+func (r proxyError) Error() string {
+	return r.TraceErr.Error()
+}
+
+// proxyError wraps another error
+type proxyError struct {
+	*TraceErr
+}
+
+type errorReport struct {
+	// OrigErrType specifies the error type as text
+	OrigErrType string
+	// OrigErrMessage specifies the original error's message
+	OrigErrMessage string
+	// Fields lists any additional fields attached to the error
+	Fields map[string]interface{}
+	// StackTrace specifies the call stack
+	StackTrace string
+	// UserMessage is the user-facing message (if any)
+	UserMessage string
+	// Caught optionally specifies the stack trace where the error
+	// has been recorded after coming over the wire
+	Caught string
+}
+
+var reportTemplate = template.Must(template.New("debugReport").Parse(reportTemplateText))
+var reportTemplateText = `
+ERROR REPORT:
+Original Error: {{.OrigErrType}} {{.OrigErrMessage}}
+{{if .Fields}}Fields:
+{{range $key, $value := .Fields}}  {{$key}}: {{$value}}
+{{end}}{{end}}Stack Trace:
+{{.StackTrace}}
+{{if .Caught}}Caught:
+{{.Caught}}
+User Message: {{.UserMessage}}
+{{else}}User Message: {{.UserMessage}}{{end}}`


### PR DESCRIPTION
This PR adds the nethealth checker. [Design Doc](https://docs.google.com/document/d/1zJGGYLPWmNioanIpzuvtjZNffgFzJ-Ezkv3vP3kLKLM/edit#heading=h.208t1zijroe)

### Rationale
Satellite does not currently have a health check in place to verify network communication between peers. Blocked UDP traffic due to a firewall or other network issues may go undetected.

### Implementation
The [nethealth](https://github.com/gravitational/satellite/pull/113) service exposes a counter for the number of echo requests and timeouts from peers in a cluster. This checker pulls metrics from the nethealth service and verifies that the network communication between peers is functional. The timeout stats are recorded as a short time series data interval containing a user specified number of data points. If the packet loss percentage is above a specified threshold at each data point, the network will be considered unhealthy and will result in a failed check.