### PR TITLE
increase the amount of init timeout for the timeline

### DIFF
--- a/agent/constants.go
+++ b/agent/constants.go
@@ -51,7 +51,7 @@ const (
 
 	// timelineInitTimeout specifies the amount of time to wait for the
 	// timeline to initialize.
-	timelineInitTimeout = 5 * time.Second
+	timelineInitTimeout = time.Minute
 
 	// updateTimelineTimeout specifies the amount of time to wait for events
 	// to be stored into the timeline.


### PR DESCRIPTION
I caught some crashes in planet-agent during install on a GCE VM. It did eventually succeed, which makes me suspect the initialization can take more than 5 seconds while the system / disk is otherwise busy with the install.

```
Mar 11 02:51:52 knisbet-centos-1 systemd[1]: Started Planet Agent service.
Mar 11 02:51:59 knisbet-centos-1 planet[620]: [ERROR]: failed to create sqlite tables, failed to initialize sqlite database, failed to initialize local timeline
Mar 11 02:51:59 knisbet-centos-1 /usr/bin/planet[620]: WARN             Failed to run. error:[
                                                       ERROR REPORT:
                                                       Original Error: context.deadlineExceededError context deadline exceeded
                                                       Stack Trace:
                                                               /gopath/src/github.com/gravitational/planet/vendor/github.com/gravitational/satellite/lib/history/sqlite/sqlite.go:126 github.com/gravitational/planet/vendor/github.com/gravitational/satellite/lib/history/sqlite.(*Timeline).initSQLite
                                                               /gopath/src/github.com/gravitational/planet/vendor/github.com/gravitational/satellite/lib/history/sqlite/sqlite.go:96 github.com/gravitational/planet/vendor/github.com/gravitational/satellite/lib/history/sqlite.NewTimeline
                                                               /gopath/src/github.com/gravitational/planet/vendor/github.com/gravitational/satellite/agent/agent.go:250 github.com/gravitational/planet/vendor/github.com/gravitational/satellite/agent.initTimeline
                                                               /gopath/src/github.com/gravitational/planet/vendor/github.com/gravitational/satellite/agent/agent.go:191 github.com/gravitational/planet/vendor/github.com/gravitational/satellite/agent.New
                                                               /gopath/src/github.com/gravitational/planet/tool/planet/agent.go:265 main.runAgent
                                                               /gopath/src/github.com/gravitational/planet/tool/planet/main.go:359 main.run
                                                               /gopath/src/github.com/gravitational/planet/tool/planet/main.go:64 main.main
                                                               /opt/go/src/runtime/proc.go:200 runtime.main
                                                               /opt/go/src/runtime/asm_amd64.s:1337 runtime.goexit
                                                       User Message: failed to create sqlite tables, failed to initialize sqlite database, failed to initialize local timeline
                                                       ] planet/main.go:737
Mar 11 02:51:59 knisbet-centos-1 systemd[1]: planet-agent.service: Main process exited, code=exited, status=255/EXCEPTION
Mar 11 02:51:59 knisbet-centos-1 systemd[1]: planet-agent.service: Failed with result 'exit-code'.
Mar 11 02:52:04 knisbet-centos-1 systemd[1]: planet-agent.service: Service RestartSec=5s expired, scheduling restart.
Mar 11 02:52:04 knisbet-centos-1 systemd[1]: planet-agent.service: Scheduled restart job, restart counter is at 3.
Mar 11 02:52:04 knisbet-centos-1 systemd[1]: Stopped Planet Agent service.
Mar 11 02:52:04 knisbet-centos-1 systemd[1]: Starting Planet Agent service...
Mar 11 02:52:04 knisbet-centos-1 systemctl[656]: active
Mar 11 02:52:04 knisbet-centos-1 systemctl[657]: active
Mar 11 02:52:04 knisbet-centos-1 systemd[1]: Started Planet Agent service.
Mar 11 02:52:12 knisbet-centos-1 /usr/bin/planet[658]: WARN             Failed to run. error:[
                                                       ERROR REPORT:
                                                       Original Error: context.deadlineExceededError context deadline exceeded
                                                       Stack Trace:
                                                               /gopath/src/github.com/gravitational/planet/vendor/github.com/gravitational/satellite/lib/history/sqlite/sqlite.go:126 github.com/gravitational/planet/vendor/github.com/gravitational/satellite/lib/history/sqlite.(*Timeline).initSQLite
                                                               /gopath/src/github.com/gravitational/planet/vendor/github.com/gravitational/satellite/lib/history/sqlite/sqlite.go:96 github.com/gravitational/planet/vendor/github.com/gravitational/satellite/lib/history/sqlite.NewTimeline
                                                               /gopath/src/github.com/gravitational/planet/vendor/github.com/gravitational/satellite/agent/agent.go:250 github.com/gravitational/planet/vendor/github.com/gravitational/satellite/agent.initTimeline
                                                               /gopath/src/github.com/gravitational/planet/vendor/github.com/gravitational/satellite/agent/agent.go:200 github.com/gravitational/planet/vendor/github.com/gravitational/satellite/agent.New
                                                               /gopath/src/github.com/gravitational/planet/tool/planet/agent.go:265 main.runAgent
                                                               /gopath/src/github.com/gravitational/planet/tool/planet/main.go:359 main.run
                                                               /gopath/src/github.com/gravitational/planet/tool/planet/main.go:64 main.main
                                                               /opt/go/src/runtime/proc.go:200 runtime.main
                                                               /opt/go/src/runtime/asm_amd64.s:1337 runtime.goexit
                                                       User Message: failed to create sqlite tables, failed to initialize sqlite database, failed to initialize timeline
                                                       ] planet/main.go:737
Mar 11 02:52:12 knisbet-centos-1 planet[658]: [ERROR]: failed to create sqlite tables, failed to initialize sqlite database, failed to initialize timeline
Mar 11 02:52:12 knisbet-centos-1 systemd[1]: planet-agent.service: Main process exited, code=exited, status=255/EXCEPTION
Mar 11 02:52:12 knisbet-centos-1 systemd[1]: planet-agent.service: Failed with result 'exit-code'.
Mar 11 02:52:18 knisbet-centos-1 systemd[1]: planet-agent.service: Service RestartSec=5s expired, scheduling restart.
Mar 11 02:52:18 knisbet-centos-1 systemd[1]: planet-agent.service: Scheduled restart job, restart counter is at 4.
```