### PR TITLE
Request with context

### DIFF
--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -275,10 +275,11 @@ func fetchNethealthMetrics(ctx context.Context, addr string) (map[string]network
 	//      # TYPE nethealth_echo_timeout_total counter
 	//      nethealth_echo_timeout_total{node_name="10.128.0.96",peer_name="10.128.0.70"} 37
 	//      nethealth_echo_timeout_total{node_name="10.128.0.96",peer_name="10.128.0.97"} 0
-	req, err := http.NewRequestWithContext(ctx, "GET", addr+"/metrics", nil)
+	req, err := http.NewRequest("GET", addr+"/metrics", nil)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
RequestWithContext is introduced in go v1.13. The current version of
golangci we are using does not support linting for go v1.13. May want to look into updating golangci. For now, fall back to creating a new request and adding context afterwards.