### PR TITLE
[5.5.x] Parsing error no longer tiggers failed probe

### DIFF
--- a/monitoring/nethealth_test.go
+++ b/monitoring/nethealth_test.go
@@ -223,10 +223,7 @@ func (s *NethealthSuite) TestParseMetricsSuccess(c *C) {
 	for _, testCase := range testCases {
 		testCase := testCase
 
-		metricFamilies, err := s.textToMetrics(testCase.metrics)
-		c.Assert(err, IsNil, testCase.comment)
-
-		netData, err := parseMetrics(metricFamilies)
+		netData, err := parseMetrics([]byte(testCase.metrics))
 		c.Assert(err, IsNil, testCase.comment)
 		c.Assert(netData, test.DeepCompare, testCase.expected)
 	}
@@ -287,10 +284,7 @@ func (s *NethealthSuite) TestParseMetricsFailure(c *C) {
 	for _, testCase := range testCases {
 		testCase := testCase
 
-		metricFamilies, err := s.textToMetrics(testCase.metrics)
-		c.Assert(err, IsNil, testCase.comment)
-
-		_, err = parseMetrics(metricFamilies)
+		_, err := parseMetrics([]byte(testCase.metrics))
 		c.Assert(err.Error(), Equals, testCase.expected, testCase.comment)
 	}
 }


### PR DESCRIPTION
Parsing errors will only be logged and will no longer trigger a failed probe.

Resolves gravitational/gravity#1307