### PR TITLE
[5.5.x] Fix error handling

### DIFF
--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -117,7 +117,7 @@ func (c *nethealthChecker) Check(ctx context.Context, reporter health.Reporter) 
 func (c *nethealthChecker) check(ctx context.Context, reporter health.Reporter) error {
 	addr, err := c.getNethealthAddr()
 	if trace.IsNotFound(err) {
-		log.Debug("Nethealth pod was not found.")
+		log.Warn("Nethealth pod was not found.")
 		return nil // pod was not found, log and treat gracefully
 	}
 	if err != nil {

--- a/monitoring/nethealth_test.go
+++ b/monitoring/nethealth_test.go
@@ -167,7 +167,7 @@ func (s *NethealthSuite) TestNethealthVerification(c *C) {
 		},
 		{
 			comment:  Commentf("Expected failed probe. Timeouts increase at each interval."),
-			expected: &health.Probes{NewProbeFromErr(nethealthCheckerID, nethealthDetail(testNode), nil)},
+			expected: &health.Probes{nethealthFailureProbe(nethealthCheckerID, testNode, abovePLT)},
 			storedData: peerData{
 				packetLoss: s.newPacketLoss(abovePLT, abovePLT, abovePLT, abovePLT, abovePLT),
 			},


### PR DESCRIPTION
More error handling fixes.

- Log pod not found error with log level WARN instead of DEBUG.
- Report last recorded packet loss percentage when probes fails.
- Previously reporting additional success probe even if checks failed.

Also fix `getNethealthAddr` by removing the field selector. Cannot rely on `spec.nodeName` to be equal to the advertised IP. Also `status.hostIP` seems to be unsupported as a field selector.