### PR TITLE
[5.5.x] Fix sequence overflow bug

### DIFF
--- a/lib/nethealth/nethealth.go
+++ b/lib/nethealth/nethealth.go
@@ -487,7 +487,7 @@ func (s *Server) processAck(e messageWrapper) error {
 		return nil
 	default:
 		//unexpected / unknown
-		return trace.BadParameter("received unexpected icmp message type").(trace.Error).AddField("type", e.message.Type)
+		return trace.BadParameter("received unexpected icmp message type").AddField("type", e.message.Type)
 	}
 
 	switch pkt := e.message.Body.(type) {
@@ -497,8 +497,9 @@ func (s *Server) processAck(e messageWrapper) error {
 			return trace.Wrap(err)
 		}
 		if uint16(pkt.Seq) != uint16(peer.echoCounter) {
-			return trace.BadParameter("response sequence doesn't match latest request. Expected %d, received %d",
-				uint16(pkt.Seq), uint16(peer.echoCounter))
+			return trace.BadParameter("response sequence doesn't match latest request.").
+				AddField("expected", uint16(peer.echoCounter)).
+				AddField("received", uint16(pkt.Seq))
 		}
 
 		rtt := e.rxTime.Sub(peer.echoTime)
@@ -509,7 +510,8 @@ func (s *Server) processAck(e messageWrapper) error {
 		s.WithFields(logrus.Fields{
 			"peer_name": peer.name,
 			"peer_addr": peer.addr,
-			"id":        peer.echoCounter,
+			"counter":   peer.echoCounter,
+			"seq":       uint16(peer.echoCounter),
 			"rtt":       rtt,
 		}).Debug("Ack.")
 	default:

--- a/lib/nethealth/nethealth.go
+++ b/lib/nethealth/nethealth.go
@@ -497,7 +497,8 @@ func (s *Server) processAck(e messageWrapper) error {
 			return trace.Wrap(err)
 		}
 		if uint16(pkt.Seq) != uint16(peer.echoCounter) {
-			return trace.BadParameter("Response sequence doesn't match latest request.")
+			return trace.BadParameter("response sequence doesn't match latest request. Expected %d, received %d",
+				uint16(pkt.Seq), uint16(peer.echoCounter))
 		}
 
 		rtt := e.rxTime.Sub(peer.echoTime)

--- a/lib/nethealth/nethealth.go
+++ b/lib/nethealth/nethealth.go
@@ -496,7 +496,7 @@ func (s *Server) processAck(e messageWrapper) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if pkt.Seq != peer.echoCounter {
+		if uint16(pkt.Seq) != uint16(peer.echoCounter) {
 			return trace.BadParameter("Response sequence doesn't match latest request.")
 		}
 
@@ -508,7 +508,7 @@ func (s *Server) processAck(e messageWrapper) error {
 		s.WithFields(logrus.Fields{
 			"peer_name": peer.name,
 			"peer_addr": peer.addr,
-			"id":        pkt.Seq,
+			"id":        peer.echoCounter,
 			"rtt":       rtt,
 		}).Debug("Ack.")
 	default:


### PR DESCRIPTION
Marshalling an icmp message into an echo request converts the sequence number into uint16. This causes nethealth to think that the received echo responses are out of order once the echoCounter reaches 65535.

- Convert sequence number and echoCounter to uint16 when comparing.
- Log only echo counter for consistency even though it may not reflect
the actual sequence number used in the icmp echo request.