### PR TITLE
[5.5.x] Need to unlock if client connection exists

### DIFF
--- a/build.go
+++ b/build.go
@@ -39,7 +39,7 @@ var (
 	nethealthRegistryImage = env("NETHEALTH_REGISTRY_IMAGE", "quay.io/gravitational/nethealth-dev")
 
 	// baseImage is the base OS image to use for containers
-	baseImage = "ubuntu:18.10"
+	baseImage = "ubuntu:19.10"
 
 	// buildVersion allows override of the version string from env variable
 	buildVersion = env("BUILD_VERSION", "")

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -161,6 +161,9 @@ func (c *nethealthChecker) getNethealthAddr() (addr string, err error) {
 
 	for _, pod := range pods.Items {
 		if pod.Status.HostIP == c.AdvertiseIP {
+			if pod.Status.PodIP == "" {
+				return addr, trace.NotFound("local nethealth pod IP has not been assigned yet.")
+			}
 			return fmt.Sprintf("http://%s:%d", pod.Status.PodIP, c.NethealthPort), nil
 		}
 	}

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -109,6 +109,7 @@ func (c *nethealthChecker) Name() string {
 func (c *nethealthChecker) Check(ctx context.Context, reporter health.Reporter) {
 	err := c.check(ctx, reporter)
 	if err != nil {
+		log.WithError(err).Warn("Failed to verify nethealth")
 		reporter.Add(NewProbeFromErr(c.Name(), "failed to verify nethealth", err))
 		return
 	}

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -120,7 +120,7 @@ func (c *nethealthChecker) Check(ctx context.Context, reporter health.Reporter) 
 func (c *nethealthChecker) check(ctx context.Context, reporter health.Reporter) error {
 	addr, err := c.getNethealthAddr()
 	if trace.IsNotFound(err) {
-		log.Warn("Nethealth pod was not found.")
+		log.WithError(err).Warn("Nethealth pod was not found.")
 		return nil // pod was not found, log and treat gracefully
 	}
 	if err != nil {

--- a/monitoring/timedrift.go
+++ b/monitoring/timedrift.go
@@ -292,6 +292,7 @@ func (c *timeDriftChecker) shouldCheckNode(node serf.Member) bool {
 func (c *timeDriftChecker) getAgentClient(ctx context.Context, node serf.Member) (client.Client, error) {
 	c.mu.Lock()
 	if conn, exists := c.clients[node.Addr.String()]; exists {
+		c.mu.Unlock()
 		return conn, nil
 	}
 	c.mu.Unlock()

--- a/monitoring/timedrift.go
+++ b/monitoring/timedrift.go
@@ -297,16 +297,25 @@ func (c *timeDriftChecker) getAgentClient(ctx context.Context, node serf.Member)
 	}
 	c.mu.Unlock()
 
-	conn, err := c.DialRPC(ctx, &node)
+	newConn, err := c.DialRPC(ctx, &node)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	c.mu.Lock()
-	c.clients[node.Addr.String()] = conn
-	c.mu.Unlock()
+	defer c.mu.Unlock()
 
-	return conn, nil
+	// Close newly created client connection if a new client was already cached while dialing.
+	if conn, exists := c.clients[node.Addr.String()]; exists {
+		if err := newConn.Close(); err != nil {
+			log.WithError(err).WithField("address", node.Addr.String()).Error("Failed to close client connection.")
+		}
+		return conn, nil
+	}
+
+	// Cache and return new client connection.
+	c.clients[node.Addr.String()] = newConn
+	return newConn, nil
 }
 
 // isDriftHigh returns true if the provided drift value is over the threshold.


### PR DESCRIPTION
- While updating `getAgentClient` to avoid locking I/O, I forgot to unlock clients in the case that the client connection exists...

- Log not found error.

- Return not found error if nethealth pod IP has not yet been assigned.

TODO: I think I may have rushed and merged previous PRs too early. Will do some testing and make sure I didn't introduce any other bugs...