### PR TITLE
Remove warning severity

### DIFF
--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -293,8 +293,7 @@ func nethealthFailureProbe(name, peer string, packetLoss float64) *pb.Probe {
 		Checker: name,
 		Detail: fmt.Sprintf("overlay packet loss for node %s is higher than the allowed threshold of %.2f%%: %.2f%%",
 			peer, thresholdPercent, packetLoss*100),
-		Status:   pb.Probe_Failed,
-		Severity: pb.Probe_Warning,
+		Status: pb.Probe_Failed,
 	}
 }
 


### PR DESCRIPTION
Giving warning severity to probe prevents probe from degrading node status. Nethealth check failure should degrade node.