### PR TITLE
Log nethealth not found errors at debug level

### DIFF
--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -121,7 +121,7 @@ func (c *nethealthChecker) Check(ctx context.Context, reporter health.Reporter) 
 func (c *nethealthChecker) check(ctx context.Context, reporter health.Reporter) error {
 	addr, err := c.getNethealthAddr()
 	if trace.IsNotFound(err) {
-		log.WithError(err).Debug("Nethealth pod was not found.")
+		log.Debug("Nethealth pod was not found.")
 		return nil // pod was not found, log and treat gracefully
 	}
 	if err != nil {

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -121,7 +121,7 @@ func (c *nethealthChecker) Check(ctx context.Context, reporter health.Reporter) 
 func (c *nethealthChecker) check(ctx context.Context, reporter health.Reporter) error {
 	addr, err := c.getNethealthAddr()
 	if trace.IsNotFound(err) {
-		log.WithError(err).Warn("Nethealth pod was not found.")
+		log.WithError(err).Debug("Nethealth pod was not found.")
 		return nil // pod was not found, log and treat gracefully
 	}
 	if err != nil {


### PR DESCRIPTION
Change log level of nethealth not found errors to DEBUG. This will prevent the logs from being flooded with not found errors if the monitoring capabilities are disabled on a cluster.