### PR TITLE
[WIP] System pods checker

### DIFF
--- a/monitoring/system_pods.go
+++ b/monitoring/system_pods.go
@@ -90,7 +90,7 @@ func (r *systemPodsChecker) Check(ctx context.Context, reporter health.Reporter)
 func (r *systemPodsChecker) check(ctx context.Context, reporter health.Reporter) error {
 	pods, err := r.getPods()
 	if trace.IsNotFound(err) {
-		log.WithError(err).Debug("Failed to get system pods.")
+		log.Debug("Failed to get system pods.")
 		return nil // system pods were not found, log and treat gracefully
 	}
 	if err != nil {

--- a/monitoring/system_pods.go
+++ b/monitoring/system_pods.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gravitational/satellite/agent/health"
+	"github.com/gravitational/satellite/utils"
+
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// SystemPodsConfig specifies configuration for a system pods checkers.
+type SystemPodsConfig struct {
+	// AdvertiseIP specifies the advertised ip address of the host running this checker.
+	AdvertiseIP string
+	// KubeConfig specifies kubernetes access information.
+	*KubeConfig
+}
+
+// CheckAndSetDefaults validates that this configuration is correct and sets
+// value defaults where necessary.
+func (r *SystemPodsConfig) CheckAndSetDefaults() error {
+	var errors []error
+	if r.AdvertiseIP == "" {
+		errors = append(errors, trace.BadParameter("host advertise ip must be provided"))
+	}
+	if r.KubeConfig == nil {
+		errors = append(errors, trace.BadParameter("kubernetes access config must be provided"))
+	}
+	return trace.NewAggregate(errors...)
+}
+
+// systemPodsChecker verifies system pods are operational.
+type systemPodsChecker struct {
+	// SystemPodsConfig specifies checker configuration values.
+	SystemPodsConfig
+}
+
+// NewSystemPodsChecker returns a new system pods checker.
+func NewSystemPodsChecker(config SystemPodsConfig) (*systemPodsChecker, error) {
+	if err := config.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &systemPodsChecker{
+		SystemPodsConfig: config,
+	}, nil
+}
+
+// Name returns this checker name
+// Implements health.Checker
+func (r *systemPodsChecker) Name() string {
+	return systemPodsCheckerID
+}
+
+// Check verifies that all system pods are operational.
+// Implements health.Checker
+func (r *systemPodsChecker) Check(ctx context.Context, reporter health.Reporter) {
+	err := r.check(ctx, reporter)
+	if err != nil {
+		log.WithError(err).Warn("Failed to verify system pods")
+		reporter.Add(NewProbeFromErr(r.Name(), "failed to verify system pods", err))
+		return
+	}
+	if reporter.NumProbes() == 0 {
+		reporter.Add(NewSuccessProbe(r.Name()))
+	}
+}
+
+func (r *systemPodsChecker) check(ctx context.Context, reporter health.Reporter) error {
+	pods, err := r.getPods()
+	if trace.IsNotFound(err) {
+		log.WithError(err).Debug("Failed to get system pods.")
+		return nil // system pods were not found, log and treat gracefully
+	}
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	r.verifyPods(pods, reporter)
+	return nil
+}
+
+// getPods returns a list of the local pods that exist in the
+// systemPodsNamespace.
+func (r *systemPodsChecker) getPods() ([]corev1.Pod, error) {
+	opts := metav1.ListOptions{}
+	pods, err := r.Client.CoreV1().Pods(systemPodsNamespace).List(opts)
+	if err != nil {
+		return nil, utils.ConvertError(err) // this will convert error to a proper trace error, e.g. trace.NotFound
+	}
+
+	var localPods []corev1.Pod
+	for _, pod := range pods.Items {
+		if pod.Status.HostIP == r.AdvertiseIP {
+			localPods = append(localPods, pod)
+		}
+	}
+	return localPods, nil
+}
+
+// verifyPods verifies the pods are in a valid state. Reports a failed probe for
+// any pods that are in an invalid state.
+func (r *systemPodsChecker) verifyPods(pods []corev1.Pod, reporter health.Reporter) {
+	for _, pod := range pods {
+		if err := verifyPodStatus(pod.Name, pod.Status); err != nil {
+			reporter.Add(NewProbeFromErr(r.Name(), fmt.Sprintf("%s is in an invalid state", pod.Name), err))
+		}
+	}
+}
+
+// verifyPodStatus verifies the status phase and conditions.
+func verifyPodStatus(name string, status corev1.PodStatus) error {
+	// https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
+	switch status.Phase {
+	case corev1.PodPending, corev1.PodSucceeded:
+		return nil
+	case corev1.PodFailed:
+		return trace.BadParameter("pod has failed")
+	case corev1.PodUnknown:
+		log.Warnf("%s is in unknown state.", name)
+		return nil
+	}
+
+	// https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions
+	// If the pod phase is `Running`, all conditions are expected to be true?
+	for _, condition := range status.Conditions {
+		if condition.Status == corev1.ConditionFalse {
+			return trace.BadParameter("%s condition is false; reason: %s", condition.Type, condition.Reason)
+		}
+		if condition.Status == corev1.ConditionUnknown {
+			log.Warnf("%s condition is in an unknown state.", condition.Type)
+		}
+	}
+
+	return nil
+}
+
+const systemPodsCheckerID = "system-pods-checker"
+const systemPodsNamespace = "kube-system"

--- a/monitoring/system_pods.go
+++ b/monitoring/system_pods.go
@@ -123,14 +123,14 @@ func (r *systemPodsChecker) getPods() ([]corev1.Pod, error) {
 // any pods that are in an invalid state.
 func (r *systemPodsChecker) verifyPods(pods []corev1.Pod, reporter health.Reporter) {
 	for _, pod := range pods {
-		if err := verifyPodStatus(pod.Name, pod.Status); err != nil {
+		if err := verifyPodStatus(pod.Status); err != nil {
 			reporter.Add(NewProbeFromErr(r.Name(), fmt.Sprintf("%s is in an invalid state", pod.Name), err))
 		}
 	}
 }
 
 // verifyPodStatus verifies the status phase and conditions.
-func verifyPodStatus(name string, status corev1.PodStatus) error {
+func verifyPodStatus(status corev1.PodStatus) error {
 	// https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
 	switch status.Phase {
 	case corev1.PodPending, corev1.PodSucceeded:
@@ -138,7 +138,7 @@ func verifyPodStatus(name string, status corev1.PodStatus) error {
 	case corev1.PodFailed:
 		return trace.BadParameter("pod has failed")
 	case corev1.PodUnknown:
-		log.Warnf("%s is in unknown state.", name)
+		log.Warn("Pod is in unknown state.")
 		return nil
 	}
 

--- a/monitoring/system_pods_test.go
+++ b/monitoring/system_pods_test.go
@@ -51,7 +51,7 @@ func (r *SystemPodsSuite) TestVerifyPodStatus(c *C) {
 	}
 
 	for _, testCase := range testCases {
-		err := verifyPodStatus("", testCase.status)
+		err := verifyPodStatus(testCase.status)
 		c.Assert(err, IsNil, testCase.comment)
 	}
 }

--- a/monitoring/system_pods_test.go
+++ b/monitoring/system_pods_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	. "gopkg.in/check.v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type SystemPodsSuite struct{}
+
+var _ = Suite(&SystemPodsSuite{})
+
+// TestVerifyPodStatus verifies that the checker can correctly identify valid
+// pod status.
+func (r *SystemPodsSuite) TestVerifyPodStatus(c *C) {
+	var testCases = []struct {
+		comment CommentInterface
+		status  corev1.PodStatus
+	}{
+		{
+			comment: Commentf("Pod is pending. Expected no errors."),
+			status:  corev1.PodStatus{Phase: corev1.PodPending},
+		},
+		{
+			comment: Commentf("Pod has succeeded. Expected no errors."),
+			status:  corev1.PodStatus{Phase: corev1.PodSucceeded},
+		},
+		{
+			comment: Commentf("Pod is running. Expected no errors."),
+			status:  corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+		{
+			comment: Commentf("Pod is in unknown state. Expected no errors."),
+			status:  corev1.PodStatus{Phase: corev1.PodUnknown},
+		},
+	}
+
+	for _, testCase := range testCases {
+		err := verifyPodStatus("", testCase.status)
+		c.Assert(err, IsNil, testCase.comment)
+	}
+}


### PR DESCRIPTION
###  Description 
This PR adds a system pods checker. This checker verifies that the pods running in `kube-system` namespace are in a valid state. 

### Implementation
Each node queries k8s for pods in `kube-system` namespace. The list of pods is further filtered to only contain pods that are running locally on that node. 

The checker then verifies that the pods are in a valid state.

We start by checking the pod phase.
- If the pod is `Pending`, we consider this a valid state.
- If the pod has `Succeeded`, this usually indicates a completed job, so we consider this a valid state.
- If the pod has `Failed`, we report the pod as being in an invalid state. 
- If the pod is `Unknown`, we will log this situation and continue.
- If the pod is `Running`, we then examine the pod conditions and verify that all conditions are `true`.

### Testing
I ran some initial tests, but did not get the results I expected.

```
[vagrant@node-1 installer]$ sudo gravity status
Cluster name:           dev.test
Cluster status:         degraded
Cluster image:          telekube, version 7.1.0-alpha.1.23
Gravity version:        7.1.0-alpha.1.23 (client) / 7.1.0-alpha.1.23 (server)
Join token:             token123
Periodic updates:       Not Configured
Remote support:         Not Configured
Last completed operation:
    * 3-node install
      ID:               4a13735e-226d-4bb5-876a-02d4ba7f8c97
      Started:          Tue Apr 14 18:17 UTC (3 hours ago)
      Completed:        Tue Apr 14 18:17 UTC (3 hours ago)
Cluster endpoints:
    * Authentication gateway:
        - 172.28.128.101:32009
        - 172.28.128.103:32009
        - 172.28.128.102:32009
    * Cluster management URL:
        - https://172.28.128.101:32009
        - https://172.28.128.103:32009
        - https://172.28.128.102:32009
Cluster nodes:
    Masters:
        * node-1 / 172.28.128.101 / node
            Status:     degraded
            [×]         gravity-site-dwp5p is in an invalid state (Ready condition is false)
        * node-3 / 172.28.128.103 / node
            Status:     degraded
            [×]         gravity-site-92k4q is in an invalid state (Ready condition is false)
        * node-2 / 172.28.128.102 / node
            Status:     healthy
[ERROR]: degraded


[vagrant@node-1 installer]$ sudo kubectl get pods -nkube-system
NAMESPACE     NAME                                           READY   STATUS      RESTARTS   AGE
kube-system   bandwagon-74c7f6d7b-wplsz                      1/1     Running     0          3h20m
kube-system   bandwagon-install-537a0a-t2wb8                 0/1     Completed   0          3h20m
kube-system   coredns-64pm4                                  1/1     Running     0          3h21m
kube-system   coredns-szhs5                                  1/1     Running     0          3h21m
kube-system   coredns-wv5mg                                  1/1     Running     0          3h21m
kube-system   dns-app-install-5f861f-gmbsd                   0/1     Completed   0          3h21m
kube-system   gravity-install-cb1cf8-dgflv                   0/1     Completed   0          3h18m
kube-system   gravity-site-92k4q                             0/1     Running     2          3h16m
kube-system   gravity-site-bbkvb                             1/1     Running     0          3h16m
kube-system   gravity-site-dwp5p                             0/1     Running     2          3h16m
kube-system   log-collector-588448bfc8-cjvvx                 1/1     Running     3          3h20m
kube-system   logging-app-install-5a9f70-7vhfw               0/1     Completed   0          3h20m
kube-system   lr-aggregator-7df89644fb-9jgxc                 1/1     Running     0          3h20m
kube-system   lr-collector-fwj44                             1/1     Running     3          3h20m
kube-system   lr-collector-vfxkv                             1/1     Running     3          3h20m
kube-system   lr-collector-x2ltp                             1/1     Running     3          3h20m
kube-system   lr-forwarder-6945f599cc-96mz6                  1/1     Running     3          3h20m
kube-system   monitoring-app-install-c3a523-sjnmm            0/1     Completed   0          3h20m
kube-system   site-app-post-install-48ebb0-bc7bw             0/1     Completed   2          3h16m
kube-system   storage-app-install-d14864-xpwnc               0/1     Completed   0          3h20m
kube-system   tiller-app-bootstrap-8dd898-529q7              0/1     Completed   0          3h19m
kube-system   tiller-deploy-6fbd4cb856-9c87c                 1/1     Running     0          3h18m
```

With this checker, all system pods are considered to be in a valid state except for the `gravity-site` pod. Two of the pods are `Running` but are not in a `Ready` state. 

Is my cluster running in an invalid state, or are the `gravity-site` pods expected to be `Running` while not `Ready`?