### PR TITLE
System pods checker

### DIFF
--- a/lib/kubernetes/constants.go
+++ b/lib/kubernetes/constants.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+// AllNamespaces can be used to query pods in all namespaces.
+const AllNamespaces = ""

--- a/lib/kubernetes/constants.go
+++ b/lib/kubernetes/constants.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2020 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/kubernetes/names.go
+++ b/lib/kubernetes/names.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2016 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubernetes
 
 import (

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -39,7 +39,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 // NethealthConfig specifies configuration for a nethealth checker.
@@ -547,15 +546,9 @@ const (
 
 // nethealthLabelSelector defines label selector used when querying for
 // nethealth pods.
-var nethealthLabelSelector = mustLabelSelector(metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
-	MatchLabels: map[string]string{
-		"k8s-app": "nethealth",
-	},
-}))
-
-func mustLabelSelector(selector labels.Selector, err error) labels.Selector {
-	if err != nil {
-		panic(err)
-	}
-	return selector
-}
+var nethealthLabelSelector = utils.MustLabelSelector(
+	metav1.LabelSelectorAsSelector(
+		&metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"k8s-app": "nethealth",
+			}}))

--- a/monitoring/system_pods.go
+++ b/monitoring/system_pods.go
@@ -90,7 +90,7 @@ func (r *systemPodsChecker) Check(ctx context.Context, reporter health.Reporter)
 func (r *systemPodsChecker) check(ctx context.Context, reporter health.Reporter) error {
 	pods, err := r.getPods()
 	if trace.IsNotFound(err) {
-		log.WithError(err).Debug("Failed to get system pods.")
+		log.Debug("Failed to get system pods.")
 		return nil // system pods were not found, log and treat gracefully
 	}
 	if err != nil {

--- a/monitoring/system_pods.go
+++ b/monitoring/system_pods.go
@@ -82,7 +82,14 @@ func (r *systemPodsChecker) Check(ctx context.Context, reporter health.Reporter)
 	err := r.check(ctx, reporter)
 	if err != nil {
 		log.WithError(err).Warn("Failed to verify critical system pods")
-		reporter.Add(NewProbeFromErr(r.Name(), "failed to verify critical system pods", err))
+		// TODO: set probe to critical
+		reporter.Add(&pb.Probe{
+			Checker:  r.Name(),
+			Detail:   "failed to verify critical system pods",
+			Error:    trace.UserMessage(err),
+			Status:   pb.Probe_Failed,
+			Severity: pb.Probe_Warning,
+		})
 		return
 	}
 	if reporter.NumProbes() == 0 {
@@ -193,9 +200,10 @@ func verifyConditionIsTrue(condition corev1.PodCondition) error {
 // check for the pod specified by podName and namespace.
 func systemPodsFailureProbe(checkerName, podName, namespace string) *pb.Probe {
 	return &pb.Probe{
-		Checker: checkerName,
-		Detail:  fmt.Sprintf("pod %s running in namespace %s is in an invalid state", podName, namespace),
-		Status:  pb.Probe_Failed,
+		Checker:  checkerName,
+		Detail:   fmt.Sprintf("pod %s running in namespace %s is in an invalid state", podName, namespace),
+		Status:   pb.Probe_Failed,
+		Severity: pb.Probe_Warning, // TODO: set probe to critical
 	}
 }
 

--- a/monitoring/system_pods.go
+++ b/monitoring/system_pods.go
@@ -81,8 +81,8 @@ func (r *systemPodsChecker) Name() string {
 func (r *systemPodsChecker) Check(ctx context.Context, reporter health.Reporter) {
 	err := r.check(ctx, reporter)
 	if err != nil {
-		log.WithError(err).Warn("Failed to verify system pods")
-		reporter.Add(NewProbeFromErr(r.Name(), "failed to verify system pods", err))
+		log.WithError(err).Warn("Failed to verify critical system pods")
+		reporter.Add(NewProbeFromErr(r.Name(), "failed to verify critical system pods", err))
 		return
 	}
 	if reporter.NumProbes() == 0 {
@@ -93,7 +93,7 @@ func (r *systemPodsChecker) Check(ctx context.Context, reporter health.Reporter)
 func (r *systemPodsChecker) check(ctx context.Context, reporter health.Reporter) error {
 	pods, err := r.getPods()
 	if trace.IsNotFound(err) {
-		log.Debug("No system pods found.")
+		log.Debug("No critical system pods found.")
 		return nil // system pods were not found, log and treat gracefully
 	}
 	if err != nil {
@@ -104,7 +104,7 @@ func (r *systemPodsChecker) check(ctx context.Context, reporter health.Reporter)
 	return nil
 }
 
-// getPods returns a list of the local pods that have the system pod label.
+// getPods returns a list of the local pods that have the `critical` label.
 func (r *systemPodsChecker) getPods() ([]corev1.Pod, error) {
 	opts := metav1.ListOptions{
 		LabelSelector: systemPodsSelector.String(),
@@ -201,10 +201,10 @@ func systemPodsFailureProbe(checkerName, podName, namespace string) *pb.Probe {
 
 const systemPodsCheckerID = "system-pods-checker"
 
-// systemPodsSelector defines a label selector used to query system pods.
+// systemPodsSelector defines a label selector used to query critical system pods.
 var systemPodsSelector = utils.MustLabelSelector(
 	metav1.LabelSelectorAsSelector(
 		&metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{
-				{Key: "system-pod", Operator: metav1.LabelSelectorOpExists},
+				{Key: "critical", Operator: metav1.LabelSelectorOpExists},
 			}}))

--- a/monitoring/system_pods.go
+++ b/monitoring/system_pods.go
@@ -29,11 +29,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// SystemPodsConfig specifies configuration for a system pods checkers.
+// SystemPodsConfig specifies configuration for a system pods checker.
 type SystemPodsConfig struct {
 	// AdvertiseIP specifies the advertised ip address of the host running this checker.
 	AdvertiseIP string
-	// KubeConfig specifies kubernetes access information.
+	// KubeConfig specifies kubernetes access configuration.
 	*KubeConfig
 }
 

--- a/monitoring/system_pods.go
+++ b/monitoring/system_pods.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gravitational/satellite/agent/health"
+	"github.com/gravitational/satellite/utils"
+
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// SystemPodsConfig specifies configuration for a system pods checkers.
+type SystemPodsConfig struct {
+	// AdvertiseIP specifies the advertised ip address of the host running this checker.
+	AdvertiseIP string
+	// KubeConfig specifies kubernetes access information.
+	*KubeConfig
+}
+
+// CheckAndSetDefaults validates that this configuration is correct and sets
+// value defaults where necessary.
+func (r *SystemPodsConfig) CheckAndSetDefaults() error {
+	var errors []error
+	if r.AdvertiseIP == "" {
+		errors = append(errors, trace.BadParameter("host advertise ip must be provided"))
+	}
+	if r.KubeConfig == nil {
+		errors = append(errors, trace.BadParameter("kubernetes access config must be provided"))
+	}
+	return trace.NewAggregate(errors...)
+}
+
+// systemPodsChecker verifies system pods are operational.
+type systemPodsChecker struct {
+	// SystemPodsConfig specifies checker configuration values.
+	SystemPodsConfig
+}
+
+// NewSystemPodsChecker returns a new system pods checker.
+func NewSystemPodsChecker(config SystemPodsConfig) (*systemPodsChecker, error) {
+	if err := config.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &systemPodsChecker{
+		SystemPodsConfig: config,
+	}, nil
+}
+
+// Name returns this checker name
+// Implements health.Checker
+func (r *systemPodsChecker) Name() string {
+	return systemPodsCheckerID
+}
+
+// Check verifies that all system pods are operational.
+// Implements health.Checker
+func (r *systemPodsChecker) Check(ctx context.Context, reporter health.Reporter) {
+	err := r.check(ctx, reporter)
+	if err != nil {
+		log.WithError(err).Warn("Failed to verify system pods")
+		reporter.Add(NewProbeFromErr(r.Name(), "failed to verify system pods", err))
+		return
+	}
+	if reporter.NumProbes() == 0 {
+		reporter.Add(NewSuccessProbe(r.Name()))
+	}
+}
+
+func (r *systemPodsChecker) check(ctx context.Context, reporter health.Reporter) error {
+	pods, err := r.getPods()
+	if trace.IsNotFound(err) {
+		log.WithError(err).Debug("Failed to get system pods.")
+		return nil // system pods were not found, log and treat gracefully
+	}
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	r.verifyPods(pods, reporter)
+	return nil
+}
+
+// getPods returns a list of the local pods that exist in the
+// systemPodsNamespace.
+func (r *systemPodsChecker) getPods() ([]corev1.Pod, error) {
+	opts := metav1.ListOptions{}
+	pods, err := r.Client.CoreV1().Pods(systemPodsNamespace).List(opts)
+	if err != nil {
+		return nil, utils.ConvertError(err) // this will convert error to a proper trace error, e.g. trace.NotFound
+	}
+
+	var localPods []corev1.Pod
+	for _, pod := range pods.Items {
+		if pod.Status.HostIP == r.AdvertiseIP {
+			localPods = append(localPods, pod)
+		}
+	}
+	return localPods, nil
+}
+
+// verifyPods verifies the pods are in a valid state. Reports a failed probe for
+// any pods that are in an invalid state.
+func (r *systemPodsChecker) verifyPods(pods []corev1.Pod, reporter health.Reporter) {
+	for _, pod := range pods {
+		if err := verifyPodStatus(pod.Name, pod.Status); err != nil {
+			reporter.Add(NewProbeFromErr(r.Name(), fmt.Sprintf("%s is in an invalid state", pod.Name), err))
+		}
+	}
+}
+
+// verifyPodStatus verifies the status phase and conditions.
+func verifyPodStatus(name string, status corev1.PodStatus) error {
+	// https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
+	switch status.Phase {
+	case corev1.PodPending, corev1.PodSucceeded:
+		return nil
+	case corev1.PodFailed:
+		return trace.BadParameter("pod has failed")
+	case corev1.PodUnknown:
+		log.Warnf("%s is in unknown state.", name)
+		return nil
+	}
+
+	// https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions
+	// If the pod phase is `Running`, all conditions are expected to be true?
+	for _, condition := range status.Conditions {
+		if condition.Status == corev1.ConditionFalse {
+			return trace.BadParameter("%s condition is false; reason: %s", condition.Type, condition.Reason)
+		}
+		if condition.Status == corev1.ConditionUnknown {
+			log.Warnf("%s condition is in an unknown state.", condition.Type)
+		}
+	}
+
+	return nil
+}
+
+const systemPodsCheckerID = "system-pods-checker"
+const systemPodsNamespace = "kube-system"

--- a/monitoring/system_pods.go
+++ b/monitoring/system_pods.go
@@ -123,14 +123,14 @@ func (r *systemPodsChecker) getPods() ([]corev1.Pod, error) {
 // any pods that are in an invalid state.
 func (r *systemPodsChecker) verifyPods(pods []corev1.Pod, reporter health.Reporter) {
 	for _, pod := range pods {
-		if err := verifyPodStatus(pod.Name, pod.Status); err != nil {
+		if err := verifyPodStatus(pod.Status); err != nil {
 			reporter.Add(NewProbeFromErr(r.Name(), fmt.Sprintf("%s is in an invalid state", pod.Name), err))
 		}
 	}
 }
 
 // verifyPodStatus verifies the status phase and conditions.
-func verifyPodStatus(name string, status corev1.PodStatus) error {
+func verifyPodStatus(status corev1.PodStatus) error {
 	// https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
 	switch status.Phase {
 	case corev1.PodPending, corev1.PodSucceeded:
@@ -138,7 +138,7 @@ func verifyPodStatus(name string, status corev1.PodStatus) error {
 	case corev1.PodFailed:
 		return trace.BadParameter("pod has failed")
 	case corev1.PodUnknown:
-		log.Warnf("%s is in unknown state.", name)
+		log.Warn("Pod is in unknown state.")
 		return nil
 	}
 

--- a/monitoring/system_pods.go
+++ b/monitoring/system_pods.go
@@ -164,9 +164,9 @@ func verifyConditions(conditions []corev1.PodCondition) error {
 func verifyCondition(condition corev1.PodCondition) error {
 	// https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions
 	switch condition.Type {
-	case corev1.PodScheduled, corev1.PodInitialized, corev1.ContainersReady:
+	case corev1.PodScheduled, corev1.PodInitialized:
 		return trace.Wrap(verifyConditionIsTrue(condition))
-	case corev1.PodReady:
+	case corev1.PodReady, corev1.ContainersReady:
 		return nil // `Running` pods are not always expected to be `Ready`. e.g. `gravity-site`.
 	default:
 		log.WithField("condition", condition.Type).Warnf("Received invalid pod condition.")

--- a/monitoring/system_pods.go
+++ b/monitoring/system_pods.go
@@ -37,9 +37,9 @@ type SystemPodsConfig struct {
 	*KubeConfig
 }
 
-// CheckAndSetDefaults validates that this configuration is correct and sets
+// checkAndSetDefaults validates that this configuration is correct and sets
 // value defaults where necessary.
-func (r *SystemPodsConfig) CheckAndSetDefaults() error {
+func (r *SystemPodsConfig) checkAndSetDefaults() error {
 	var errors []error
 	if r.AdvertiseIP == "" {
 		errors = append(errors, trace.BadParameter("host advertise ip must be provided"))
@@ -58,7 +58,7 @@ type systemPodsChecker struct {
 
 // NewSystemPodsChecker returns a new system pods checker.
 func NewSystemPodsChecker(config SystemPodsConfig) (*systemPodsChecker, error) {
-	if err := config.CheckAndSetDefaults(); err != nil {
+	if err := config.checkAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/monitoring/system_pods.go
+++ b/monitoring/system_pods.go
@@ -220,11 +220,11 @@ func systemPodsFailureProbe(checkerName, namespace, podName string, err error) *
 const systemPodsCheckerID = "system-pods-checker"
 const systemPodKey = "gravitational.io/critical-pod"
 
-// NOTE: Currently, there is limited documentation k8s container state. Information
-// on container state can be found in kubelet pkg:
+// NOTE: Currently, there is limited documentation on k8s container state.
+// Information on container state can be found in kubelet pkg:
 // https://github.com/kubernetes/kubernetes/tree/master/pkg/kubelet
 
-// These states usually do not indiate an unhealthy pod.
+// These states usually do not indicate an unhealthy pod.
 const (
 	// podInitializing state indicates that the container is waiting on an initContainer to terminate.
 	podInitializing = "PodInitializing"

--- a/monitoring/system_pods.go
+++ b/monitoring/system_pods.go
@@ -46,7 +46,6 @@ func (r *SystemPodsConfig) checkAndSetDefaults() error {
 	var errors []error
 	if r.NodeName == "" {
 		errors = append(errors, trace.BadParameter("node name must be provided"))
-
 	}
 	if r.KubeConfig == nil {
 		errors = append(errors, trace.BadParameter("kubernetes access config must be provided"))
@@ -103,7 +102,8 @@ func (r *systemPodsChecker) check(ctx context.Context, reporter health.Reporter)
 	return nil
 }
 
-// getPods returns a list of the local pods that have the `critical` label.
+// getPods returns a list of the local pods that have the
+// `gravitational.io/critical-pod` label.
 func (r *systemPodsChecker) getPods() ([]corev1.Pod, error) {
 	opts := metav1.ListOptions{
 		LabelSelector: systemPodsSelector.String(),
@@ -137,7 +137,7 @@ func (r *systemPodsChecker) verifyPods(pods []corev1.Pod, reporter health.Report
 			}
 
 		// PodPending indicates that some containers are still in a waiting state.
-		// All initContainers and containers need to verified to ensure that
+		// All initContainers and containers need to be verified to ensure that
 		// a container is not stuck in an unhealthy state.
 		case corev1.PodPending:
 			var err error

--- a/monitoring/system_pods_test.go
+++ b/monitoring/system_pods_test.go
@@ -249,7 +249,7 @@ func (r *SystemPodsSuite) TestInvalidPodStatus(c *C) {
 			},
 		},
 		{
-			comment: Commentf("Pod Running && Container Copmleted/CrashLoopBackOff"),
+			comment: Commentf("Pod Running && Container Completed/CrashLoopBackOff"),
 			pod: corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod-running",

--- a/monitoring/system_pods_test.go
+++ b/monitoring/system_pods_test.go
@@ -51,7 +51,7 @@ func (r *SystemPodsSuite) TestVerifyPodStatus(c *C) {
 	}
 
 	for _, testCase := range testCases {
-		err := verifyPodStatus("", testCase.status)
+		err := verifyPodStatus(testCase.status)
 		c.Assert(err, IsNil, testCase.comment)
 	}
 }

--- a/monitoring/system_pods_test.go
+++ b/monitoring/system_pods_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	. "gopkg.in/check.v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type SystemPodsSuite struct{}
+
+var _ = Suite(&SystemPodsSuite{})
+
+// TestVerifyPodStatus verifies that the checker can correctly identify valid
+// pod status.
+func (r *SystemPodsSuite) TestVerifyPodStatus(c *C) {
+	var testCases = []struct {
+		comment CommentInterface
+		status  corev1.PodStatus
+	}{
+		{
+			comment: Commentf("Pod is pending. Expected no errors."),
+			status:  corev1.PodStatus{Phase: corev1.PodPending},
+		},
+		{
+			comment: Commentf("Pod has succeeded. Expected no errors."),
+			status:  corev1.PodStatus{Phase: corev1.PodSucceeded},
+		},
+		{
+			comment: Commentf("Pod is running. Expected no errors."),
+			status:  corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+		{
+			comment: Commentf("Pod is in unknown state. Expected no errors."),
+			status:  corev1.PodStatus{Phase: corev1.PodUnknown},
+		},
+	}
+
+	for _, testCase := range testCases {
+		err := verifyPodStatus("", testCase.status)
+		c.Assert(err, IsNil, testCase.comment)
+	}
+}

--- a/monitoring/system_pods_test.go
+++ b/monitoring/system_pods_test.go
@@ -51,7 +51,6 @@ func (r *SystemPodsSuite) TestVerifyPodStatus(c *C) {
 	}
 
 	for _, testCase := range testCases {
-		err := verifyPodStatus(testCase.status)
-		c.Assert(err, IsNil, testCase.comment)
+		c.Assert(verifyPodStatus(testCase.status), IsNil, testCase.comment)
 	}
 }

--- a/monitoring/system_pods_test.go
+++ b/monitoring/system_pods_test.go
@@ -236,7 +236,7 @@ func (r *SystemPodsSuite) TestInvalidPodStatus(c *C) {
 							Name: "init-waiting",
 							State: corev1.ContainerState{
 								Waiting: &corev1.ContainerStateWaiting{
-									Reason: imagePullBackOff,
+									Reason: errImagePullBackOff,
 								},
 							},
 						},
@@ -270,7 +270,7 @@ func (r *SystemPodsSuite) TestInvalidPodStatus(c *C) {
 							Name: "cont-waiting",
 							State: corev1.ContainerState{
 								Waiting: &corev1.ContainerStateWaiting{
-									Reason: crashLoopBackOff,
+									Reason: errCrashLoopBackOff,
 								},
 							},
 						},
@@ -280,6 +280,32 @@ func (r *SystemPodsSuite) TestInvalidPodStatus(c *C) {
 			expected: &health.Probes{
 				systemPodsFailureProbe(r.Name(), "test", "pod-running",
 					trace.BadParameter("cont-waiting waiting: CrashLoopBackOff")),
+			},
+		},
+		{
+			comment: Commentf("Pod Running && Container Error"),
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-running",
+					Namespace: "test",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "cont-terminated",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									Reason: containerError,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &health.Probes{
+				systemPodsFailureProbe(r.Name(), "test", "pod-running",
+					trace.BadParameter("cont-terminated terminated: Error")),
 			},
 		},
 	}

--- a/utils/k8s.go
+++ b/utils/k8s.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// MustLabelSelector panics if the provided error is not nil. Returns
+// the labels.Selector.
+func MustLabelSelector(selector labels.Selector, err error) labels.Selector {
+	if err != nil {
+		panic(err)
+	}
+	return selector
+}


### PR DESCRIPTION
###  Description 
This PR adds a system pods checker. This checker verifies that all pods with the `gravitational.io/critical-pod` label is healthy.

### Implementation
The checker queries k8s for all pods with `gravitational.io/critical-pod` label. The list of pods is further filtered to only contain pods that are running locally on that node.

The checker then verifies that the pods are healthy.

We start by checking the pod phase.
- If the pod has `Succeeded`, this indicates a completed job, so the checker considers this healthy.
- If the pod has `Failed`, the checker reports the pod as being unhealthy. 
- If the pod is `Unknown`, log this situation and continue. Will not report degraded probe.
- If the pod is `Running`, the checker then verifies that all containers are `Running` or in an OK state. 
- If the pod is `Pending`, the checker then checks to see if the pod is `Initialized`.
  - If the pod is `Initialized` then the checker verifies that all containers are `Running` or in an OK state.
  - If the pod is not `Initialized` then the checker verifies that all initContainers are `Running` or in an OK state. 

Container is unhealthy if:
- `Terminated:Error` - Container terminated with an error.
- `Waiting:CrashLoopBackOff` - Container is in a crash loop.
- `Waiting:ImagePullBackOff` - Container failed to pull image.
- `Waiting:ErrImagePull` - Container failed to pull image.

### Limitations
The current implementation is a bit conservative on what it determines as an unhealthy pod. Common error states, such as, `CrashLoopBackOff` and `ImagePullBackOff` will be reported as unhealthy, but other unhealthy states may go unnoticed. It won't take much work to add additional states to the list of healthy states, so we can add them in later.

The system-pods check will not be able to report on critical pods that have not been scheduled to a pod. Need to think about this scenario some more and will look to add this feature in the future.