### PR TITLE
Filter nethealth data

### DIFF
--- a/agent/constants.go
+++ b/agent/constants.go
@@ -24,10 +24,14 @@ import (
 type MemberStatus string
 
 const (
-	MemberAlive   MemberStatus = "alive"
-	MemberLeaving              = "leaving"
-	MemberLeft                 = "left"
-	MemberFailed               = "failed"
+	// MemberAlive indicates the node is a member of the serf cluster.
+	MemberAlive MemberStatus = "alive"
+	// MemberLeaving indicates the node is in the process of leaving the serf cluster.
+	MemberLeaving = "leaving"
+	// MemberLeft indicates the node has left the serf cluster.
+	MemberLeft = "left"
+	// MemberFailed indicates the node is in a failed state.
+	MemberFailed = "failed"
 )
 
 // Role describes the agent's server role.

--- a/cmd/nethealth/main.go
+++ b/cmd/nethealth/main.go
@@ -53,6 +53,8 @@ func run() error {
 		crunPrometheusPort = crun.Flag("prom-port", "The prometheus port to bind to").Default("9801").Uint32()
 		crunNamespace      = crun.Flag("namespace", "The kubernetes namespace to watch for nethealth pods").
 					Default("monitoring").OverrideDefaultFromEnvar("POD_NAMESPACE").String()
+		crunNodeName = crun.Flag("node-name", "The name of the node we're running on").
+				OverrideDefaultFromEnvar("NODE_NAME").String()
 		crunHostIP   = crun.Flag("host-ip", "The host IP address").OverrideDefaultFromEnvar("HOST_IP").String()
 		crunSelector = crun.Flag("pod-selector", "The kubernetes selector to identify nethealth pods").
 				Default(nethealth.DefaultSelector).String()
@@ -86,6 +88,7 @@ func run() error {
 		config := nethealth.Config{
 			PrometheusPort: *crunPrometheusPort,
 			Namespace:      *crunNamespace,
+			NodeName:       *crunNodeName,
 			HostIP:         *crunHostIP,
 			Selector:       *crunSelector,
 		}

--- a/cmd/nethealth/main.go
+++ b/cmd/nethealth/main.go
@@ -53,8 +53,7 @@ func run() error {
 		crunPrometheusPort = crun.Flag("prom-port", "The prometheus port to bind to").Default("9801").Uint32()
 		crunNamespace      = crun.Flag("namespace", "The kubernetes namespace to watch for nethealth pods").
 					Default("monitoring").OverrideDefaultFromEnvar("POD_NAMESPACE").String()
-		crunNodeName = crun.Flag("node-name", "The name of the node we're running on").
-				OverrideDefaultFromEnvar("NODE_NAME").String()
+		crunHostIP   = crun.Flag("host-ip", "The host IP address").OverrideDefaultFromEnvar("HOST_IP").String()
 		crunSelector = crun.Flag("pod-selector", "The kubernetes selector to identify nethealth pods").
 				Default(nethealth.DefaultSelector).String()
 	)
@@ -87,7 +86,7 @@ func run() error {
 		config := nethealth.Config{
 			PrometheusPort: *crunPrometheusPort,
 			Namespace:      *crunNamespace,
-			NodeName:       *crunNodeName,
+			HostIP:         *crunHostIP,
 			Selector:       *crunSelector,
 		}
 

--- a/lib/nethealth/nethealth.go
+++ b/lib/nethealth/nethealth.go
@@ -391,7 +391,10 @@ func (s *Server) resyncNethealth(pods []corev1.Pod) {
 			lastStatusChange: s.clock.Now(),
 		}
 		s.podToHost[pod.Status.PodIP] = pod.Status.HostIP
-		s.WithField("peer", pod.Status.HostIP).Info("Adding peer.")
+		s.WithFields(logrus.Fields{
+			"host_ip":  pod.Status.HostIP,
+			"pod_addr": pod.Status.PodIP,
+		}).Info("Adding peer.")
 
 		// Initialize the peer so it shows up in prometheus with a 0 count
 		s.promPeerTimeout.WithLabelValues(s.config.HostIP, pod.Status.HostIP).Add(0)
@@ -518,6 +521,7 @@ func (s *Server) sendHeartbeat(peer *peer) {
 	})
 
 	if peer.podAddr == nil || peer.podAddr.String() == "" || peer.podAddr.String() == "0.0.0.0" {
+		log.Debug("Peer does not have valid pod address.")
 		return
 	}
 

--- a/lib/nethealth/nethealth.go
+++ b/lib/nethealth/nethealth.go
@@ -379,8 +379,11 @@ func (s *Server) resyncNethealth(pods []corev1.Pod) {
 					"new_peer_addr": newAddr,
 					"old_peer_addr": peer.addr,
 				}).Info("Updating peer pod IP address.")
+
+				// update pod to host mapping
+				delete(s.addrToPeer, peer.addr.String())
 				peer.addr = newAddr
-				s.addrToPeer[pod.Status.PodIP] = pod.Status.HostIP // update pod to host mapping
+				s.addrToPeer[peer.addr.String()] = pod.Status.HostIP
 			}
 			continue
 		}

--- a/lib/nethealth/nethealth_test.go
+++ b/lib/nethealth/nethealth_test.go
@@ -81,7 +81,7 @@ func TestResyncPeerList(t *testing.T) {
 	for _, tt := range cases {
 		server.resyncNethealth(tt.pods)
 		assert.Equal(t, tt.expectedPeers, server.peers, tt.description)
-		assert.Equal(t, tt.expectedLookup, server.podToHost, tt.description)
+		assert.Equal(t, tt.expectedLookup, server.addrToPeer, tt.description)
 	}
 }
 
@@ -119,7 +119,7 @@ func newTestPod(hostIP, podIP string) v1.Pod {
 func newTestPeer(hostIP, podAddr string, ts time.Time) *peer {
 	return &peer{
 		hostIP:           hostIP,
-		podAddr:          &net.IPAddr{IP: net.ParseIP(podAddr)},
+		addr:             &net.IPAddr{IP: net.ParseIP(podAddr)},
 		lastStatusChange: ts,
 	}
 }


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR addresses issue with cluster degrading during rolling update due to nethealth check failure https://github.com/gravitational/gravity/issues/1403.

**Changes to nethealth checker**

The nethealth-checker now filters incoming nethealth data through `filterNetData` which removes data for nodes that are no longer members of the cluster. Ideally, nethealth should handle removing metrics for these nodes, but having this filter here is probably a good idea anyways.

**Changes to nethealth application**

The nethealth application now uses the nethealth pod's host IP when recording metrics. Previously, the node name would be assigned to `node_name` and `peer_name` label. We can't always rely on node name being equal to the host IP, so filtering by serf IP would be unreliable. If we store the host IP in the relevant labels, we can then reliably filter metrics using serf member IPs.

Nethealth now removes metrics for peers that have left the cluster. This change should fix the underlying problem.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Regression fix (non-breaking change which fixes a regression)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/1403

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Before changes**

- Setup multi-node cluster.
- Degrade nethealth checker using iptables to drop traffic from one node to another
```
[vagrant@node-1 ~]$ sudo iptables -A INPUT -p udp -s 172.28.128.102 -j DROP
```

- Once nodes are in a degraded state due to nethealth checker remove one of the degraded nodes.
```
[vagrant@node-1 ~]$ sudo gravity remove node-2 --force
```

- After the node is removed, the nethealth check is stuck in this state.
```
[vagrant@node-1 ~]$ sudo gravity status
Cluster name:           dev.test
Cluster status:         degraded
[...]
Cluster nodes:
    Masters:
        * node-1 (172.28.128.101, node)
            Status:     degraded
            [×]         overlay packet loss for node 172.28.128.102 is higher than the allowed threshold of 20.00%: 100.00% ()
        * node-3 (172.28.128.103, node)
            Status:     healthy
```

**After changes**
If we follow the same procedure:

- Drop udp from node-2 to node-1 and wait for nethealth check to fail.
```
[vagrant@node-1 installer]$ sudo iptables -A INPUT -p udp -s 172.28.128.102 -j DROP
[vagrant@node-1 installer]$ sudo gravity status
Cluster name:           dev.test
Cluster status:         degraded
[...]
Cluster nodes:
    Masters:
        * node-2 (172.28.128.102, node)
            Status:     degraded
            [×]         overlay packet loss for node 172.28.128.101 is higher than the allowed threshold of 20.00%: 100.00% ()
        * node-3 (172.28.128.103, node)
            Status:     healthy
        * node-1 (172.28.128.101, node)
            Status:     degraded
            [×]         overlay packet loss for node 172.28.128.102 is higher than the allowed threshold of 20.00%: 100.00% ()
```

- Now remove node-2 from the cluster.
```
[vagrant@node-1 installer]$ sudo gravity remove node-2 --force
[vagrant@node-1 installer]$ sudo gravity status
Cluster name:           dev.test
Cluster status:         degraded
[...]
Cluster nodes:
    Masters:
        * node-3 (172.28.128.103, node)
            Status:     healthy
        * node-1 (172.28.128.101, node)
            Status:     degraded
            [×]         overlay packet loss for node 172.28.128.102 is higher than the allowed threshold of 20.00%: 100.00% ()
```

- Wait for next status update cycle and nethealth check should now pass.
```
[vagrant@node-1 installer]$ sudo gravity status
Cluster name:           dev.test
Cluster status:         active
[...]
Cluster nodes:
    Masters:
        * node-3 (172.28.128.103, node)
            Status:     healthy
        * node-1 (172.28.128.101, node)
            Status:     healthy
```

If we look at the Prometheus metrics exposed by nethealth, we can see that metrics for node-2 were removed when node-2 left the cluster.

```
[vagrant@node-1 installer]$ curl 10.244.52.9:9801/metrics
[...]
# HELP nethealth_echo_request_total The number of echo requests that have been sent
# TYPE nethealth_echo_request_total counter
nethealth_echo_request_total{node_name="172.28.128.101",peer_name="172.28.128.103"} 807
# HELP nethealth_echo_timeout_total The number of echo requests that have timed out
# TYPE nethealth_echo_timeout_total counter
nethealth_echo_timeout_total{node_name="172.28.128.101",peer_name="172.28.128.103"} 0
[...]
```