### PR TITLE
Prevent nethealth check from degrading nodes

### DIFF
--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -286,7 +286,7 @@ func (c *nethealthChecker) verifyNethealthLog(peers []string) error {
 			continue
 		}
 		packetLoss := data.packetLoss[len(data.packetLoss)-1]
-		log.Errorf("Overlay packet loss for node %s is higher than the allowed threshold of %.2f%%: %.2f%%",
+		log.Warnf("Overlay packet loss for node %s is higher than the allowed threshold of %.2f%%: %.2f%%",
 			peer, thresholdPercent, packetLoss*100)
 	}
 	return nil

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -111,7 +111,7 @@ func (c *nethealthChecker) Check(ctx context.Context, reporter health.Reporter) 
 	if err != nil {
 		log.WithError(err).Warn("Failed to verify nethealth")
 
-		// Do not report failed probes for now until we fix issues with nethealth checker.
+		// TODO: uncomment once nethealth check issues are fixed.
 		// reporter.Add(NewProbeFromErr(c.Name(), "failed to verify nethealth", err))
 		return
 	}
@@ -148,6 +148,7 @@ func (c *nethealthChecker) check(ctx context.Context, reporter health.Reporter) 
 		return trace.Wrap(err, "failed to update nethealth stats")
 	}
 
+	// TODO: replace with verifyNethealth once nethealth check issues are fixed.
 	return c.verifyNethealthLog(updated)
 }
 


### PR DESCRIPTION
The nethealth check has been causing a lot of problems. I think it is probably best to prevent nethealth check from degrading nodes for now until we fix some issue with the checker. With this change, nethealth check will no longer report failed probes, instead all network issues will just be logged.