### PR TITLE
Filter nethealth data

### DIFF
--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -112,7 +112,13 @@ func (c *nethealthChecker) Check(ctx context.Context, reporter health.Reporter) 
 	err := c.check(ctx, reporter)
 	if err != nil {
 		log.WithError(err).Warn("Failed to verify nethealth")
-		reporter.Add(NewProbeFromErr(c.Name(), "failed to verify nethealth", err))
+		reporter.Add(&pb.Probe{
+			Checker:  c.Name(),
+			Detail:   "failed to verify nethealth",
+			Error:    trace.UserMessage(err),
+			Status:   pb.Probe_Failed,
+			Severity: pb.Probe_Warning,
+		})
 		return
 	}
 	if reporter.NumProbes() == 0 {
@@ -306,7 +312,8 @@ func nethealthFailureProbe(name, peer string, packetLoss float64) *pb.Probe {
 		Checker: name,
 		Detail: fmt.Sprintf("overlay packet loss for node %s is higher than the allowed threshold of %d%%: %d%%",
 			peer, int(thresholdPercent), int(packetLoss*100)),
-		Status: pb.Probe_Failed,
+		Status:   pb.Probe_Failed,
+		Severity: pb.Probe_Warning,
 	}
 }
 

--- a/monitoring/nethealth_test.go
+++ b/monitoring/nethealth_test.go
@@ -26,6 +26,8 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	. "gopkg.in/check.v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type NethealthSuite struct{}
@@ -281,6 +283,58 @@ func (s *NethealthSuite) TestParseMetricsFailure(c *C) {
 	}
 }
 
+// TestFilterByK8s verifies filterByK8s properly filters the incoming networkData.
+func (s *NethealthSuite) TestFilterByK8s(c *C) {
+	var testCases = []struct {
+		comment  CommentInterface
+		expected map[string]networkData
+		netData  map[string]networkData
+		nodes    []corev1.Node
+	}{
+		{
+			comment: Commentf("Expected original data set."),
+			expected: map[string]networkData{
+				"node-1": {},
+			},
+			netData: map[string]networkData{
+				"node-1": {},
+			},
+			nodes: []corev1.Node{
+				s.newTestNode("node-1"),
+			},
+		},
+		{
+			comment:  Commentf("Expected no network data."),
+			expected: map[string]networkData{},
+			netData: map[string]networkData{
+				"node-1": {},
+			},
+		},
+		{
+			comment: Commentf("Expected filtered data set."),
+			expected: map[string]networkData{
+				"node-1": {},
+				"node-2": {},
+			},
+			netData: map[string]networkData{
+				"node-1": {},
+				"node-2": {},
+				"node-3": {},
+			},
+			nodes: []corev1.Node{
+				s.newTestNode("node-1"),
+				s.newTestNode("node-2"),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		netData, err := filterByK8s(testCase.netData, testCase.nodes)
+		c.Assert(err, IsNil, testCase.comment)
+		c.Assert(netData, test.DeepCompare, testCase.expected, testCase.comment)
+	}
+}
+
 // newNethealthChecker returns a new nethealth checker to be used for testing.
 func (s *NethealthSuite) newNethealthChecker() *nethealthChecker {
 	return &nethealthChecker{
@@ -294,6 +348,15 @@ func (s *NethealthSuite) newPacketLoss(values ...float64) []float64 {
 	packetLoss := make([]float64, 0, testCapacity)
 	packetLoss = append(packetLoss, values...)
 	return packetLoss
+}
+
+// newTestNode constructs a new ndoe with the provided node name.
+func (s *NethealthSuite) newTestNode(name string) corev1.Node {
+	return corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
 }
 
 // textToMetrics converts the string into a map of MetricFamilies.

--- a/monitoring/nethealth_test.go
+++ b/monitoring/nethealth_test.go
@@ -350,7 +350,7 @@ func (s *NethealthSuite) newPacketLoss(values ...float64) []float64 {
 	return packetLoss
 }
 
-// newTestNode constructs a new ndoe with the provided node name.
+// newTestNode constructs a new node with the provided node name.
 func (s *NethealthSuite) newTestNode(name string) corev1.Node {
 	return corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR updates the nethealth checker to filter incoming network data. The nethealth app may persist metrics for peers that are no longer members of the cluster. Metrics for these peers need to be filtered and removed.

## Implementation
The nethealth-checker now filters incoming nethealth data through `filterNetData`. This function removes nethealth data for peers that are no longer members of the clutser. Cluster membership is determined by querying k8s nodes.

Also updated `getNethealthAddr` function to query pods by `NodeName` instead of `HostIP`.

Previous implementation https://github.com/gravitational/satellite/pull/191. 

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Before changes**

- Setup multi-node cluster.
- Degrade nethealth checker using iptables to drop traffic from one node to another
```
[vagrant@node-1 ~]$ sudo iptables -A INPUT -p udp -s 172.28.128.102 -j DROP
```

- Once nodes are in a degraded state due to nethealth checker remove one of the degraded nodes.
```
[vagrant@node-1 ~]$ sudo gravity remove node-2 --force
```

- After the node is removed, the nethealth check is stuck in this state.
```
[vagrant@node-1 ~]$ sudo gravity status
Cluster name:           dev.test
Cluster status:         degraded
[...]
Cluster nodes:
    Masters:
        * node-1 (172.28.128.101, node)
            Status:     degraded
            [×]         overlay packet loss for node 172.28.128.102 is higher than the allowed threshold of 20.00%: 100.00% ()
        * node-3 (172.28.128.103, node)
            Status:     healthy
```

**After changes** 
Using gravity 7.0.4 with dev planet build containing changes from this satellite branch.

- Setup mutli-node cluster and block udp between `node-1` and `node-2`. 
```
[vagrant@node-1 ~]$ sudo gravity status
Cluster name:           dev.test
Cluster status:         degraded
Cluster image:          telekube, version 7.0.4
Gravity version:        7.0.4 (client) / 7.0.4 (server)
[...]
Cluster nodes:
    Masters:
        * node-3 / 172.28.128.103 / node
            Status:     healthy
        * node-1 / 172.28.128.101 / node
            Status:     degraded
            [×]         overlay packet loss for node 172.28.128.102 is higher than the allowed threshold of 20.00%: 100.00%
        * node-2 / 172.28.128.102 / node
            Status:     degraded
            [×]         overlay packet loss for node 172.28.128.101 is higher than the allowed threshold of 20.00%: 100.00%
[ERROR]: degraded
```

- After we remove `node-2` from the cluster `node-1` should no longer be degraded.
```
[vagrant@node-1 ~]$ sudo gravity status
Cluster name:           dev.test
Cluster status:         active
Cluster image:          telekube, version 7.0.4
Gravity version:        7.0.4 (client) / 7.0.4 (server)
[...]
Cluster nodes:
    Masters:
        * node-3 / 172.28.128.103 / node
            Status:     healthy
        * node-1 / 172.28.128.101 / node
            Status:     healthy
```

Nethealth check functions similarly when running on worker node.

- Rejoin `node-2` with role `knode` and block udp between `node-2` and `node-3`.
```
[vagrant@node-2 ~]$ sudo gravity status
Cluster name:           dev.test
Cluster status:         degraded
Cluster image:          telekube, version 7.0.4
Gravity version:        7.0.4 (client) / 7.0.4 (server)
[...]
Cluster nodes:
    Masters:
        * node-3 / 172.28.128.103 / node
            Status:     degraded
            [×]         overlay packet loss for node 172.28.128.102 is higher than the allowed threshold of 20.00%: 100.00%
        * node-1 / 172.28.128.101 / node
            Status:     healthy
    Nodes:
        * node-2 / 172.28.128.102 / knode
            Status:     degraded
            [×]         overlay packet loss for node 172.28.128.103 is higher than the allowed threshold of 20.00%: 100.00%
[ERROR]: degraded
```

- After removing `node-3` `node-2` eventually returns to a healthy state.
```
[vagrant@node-1 ~]$ sudo gravity status
Cluster name:           dev.test
Cluster status:         active
Cluster image:          telekube, version 7.0.4
Gravity version:        7.0.4 (client) / 7.0.4 (server)
[...]
Cluster nodes:
    Masters:
        * node-1 / 172.28.128.101 / node
            Status:     healthy
    Nodes:
        * node-2 / 172.28.128.102 / knode
            Status:     healthy
```