### PR TITLE
[5.5.x] Warning severity no longer degrades nodes

### DIFF
--- a/agent/health/health.go
+++ b/agent/health/health.go
@@ -99,7 +99,7 @@ func (r Probes) GetFailed() []*pb.Probe {
 func (r Probes) Status() pb.NodeStatus_Type {
 	result := pb.NodeStatus_Running
 	for _, probe := range r {
-		if probe.Status == pb.Probe_Failed {
+		if probe.Status == pb.Probe_Failed && probe.Severity != pb.Probe_Warning {
 			result = pb.NodeStatus_Degraded
 			break
 		}

--- a/monitoring/timedrift.go
+++ b/monitoring/timedrift.go
@@ -223,8 +223,7 @@ func (c *timeDriftChecker) successProbe() *pb.Probe {
 		Checker: c.Name(),
 		Detail: fmt.Sprintf("time drift between %s and other nodes is within the allowed threshold of %s",
 			c.SerfMember.Addr, timeDriftThreshold),
-		Status:   pb.Probe_Running,
-		Severity: pb.Probe_None,
+		Status: pb.Probe_Running,
 	}
 }
 
@@ -235,8 +234,7 @@ func (c *timeDriftChecker) failureProbe(node serf.Member, drift time.Duration) *
 		Checker: c.Name(),
 		Detail: fmt.Sprintf("time drift between %s and %s is higher than the allowed threshold of %s: %s",
 			c.SerfMember.Addr, node.Addr, timeDriftThreshold, drift),
-		Status:   pb.Probe_Failed,
-		Severity: pb.Probe_Warning,
+		Status: pb.Probe_Failed,
 	}
 }
 


### PR DESCRIPTION
### Description 
This PR modifies satellite to no longer degrade nodes for probes with a `Warning` severity. Implemented in `master` at https://github.com/gravitational/satellite/pull/112. 

### Purpose 
Enabling `Warning` probes can be used to help reduce the amount of risk when introducing new health checks to gravity. New health checks can be initially added as warnings. Once they have been seen to function as expected, the check can then be switched to critical.