### PR TITLE
Delete prometheus metrics when peer is removed

### DIFF
--- a/lib/nethealth/nethealth.go
+++ b/lib/nethealth/nethealth.go
@@ -311,6 +311,7 @@ func (s *Server) loop() {
 func (s *Server) loopServiceDiscovery() {
 	s.Info("Starting DNS service discovery for nethealth pod.")
 	ticker := s.clock.NewTicker(dnsDiscoveryInterval)
+	defer ticker.Stop()
 	query := s.config.ServiceDiscoveryQuery
 
 	previousNames := []string{}
@@ -373,6 +374,9 @@ func (s *Server) resyncPeerList() error {
 		if _, ok := peerMap[key]; !ok {
 			s.WithField("peer", key).Info("Deleting peer.")
 			delete(s.peers, key)
+			s.promPeerRTT.DeleteLabelValues(s.config.NodeName, key)
+			s.promPeerRequest.DeleteLabelValues(s.config.NodeName, key)
+			s.promPeerTimeout.DeleteLabelValues(s.config.NodeName, key)
 		}
 	}
 


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR updates the nethealth application to remove prometheus metrics when a peer leaves the cluster.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
Test leave/join a node.
```
[vagrant@node-1 ~]$ curl 100.96.67.14:9801/metrics
[...]
# HELP nethealth_echo_request_total The number of echo requests that have been sent
# TYPE nethealth_echo_request_total counter
nethealth_echo_request_total{node_name="172.28.128.101",peer_name="172.28.128.102"} 2302
nethealth_echo_request_total{node_name="172.28.128.101",peer_name="172.28.128.103"} 2302
# HELP nethealth_echo_timeout_total The number of echo requests that have timed out
# TYPE nethealth_echo_timeout_total counter
nethealth_echo_timeout_total{node_name="172.28.128.101",peer_name="172.28.128.102"} 2
nethealth_echo_timeout_total{node_name="172.28.128.101",peer_name="172.28.128.103"} 3
```
- Remove `node-2 (172.28.128.102)`.
```
[vagrant@node-1 ~]$ curl 100.96.67.14:9801/metrics
[...]
# HELP nethealth_echo_request_total The number of echo requests that have been sent
# TYPE nethealth_echo_request_total counter
nethealth_echo_request_total{node_name="172.28.128.101",peer_name="172.28.128.103"} 3004
# HELP nethealth_echo_timeout_total The number of echo requests that have timed out
# TYPE nethealth_echo_timeout_total counter
nethealth_echo_timeout_total{node_name="172.28.128.101",peer_name="172.28.128.103"} 3
```
- Join `node-2`.
```
[vagrant@node-1 ~]$ curl 100.96.67.14:9801/metrics
[...]
# HELP nethealth_echo_request_total The number of echo requests that have been sent
# TYPE nethealth_echo_request_total counter
nethealth_echo_request_total{node_name="172.28.128.101",peer_name="172.28.128.102"} 129
nethealth_echo_request_total{node_name="172.28.128.101",peer_name="172.28.128.103"} 3301
# HELP nethealth_echo_timeout_total The number of echo requests that have timed out
# TYPE nethealth_echo_timeout_total counter
nethealth_echo_timeout_total{node_name="172.28.128.101",peer_name="172.28.128.102"} 0
nethealth_echo_timeout_total{node_name="172.28.128.101",peer_name="172.28.128.103"} 3
```
- Counters for `node-2` is successfully removed/reinitialized.
