### PR TITLE
Use distroless base image

### DIFF
--- a/Dockerfile.nethealth
+++ b/Dockerfile.nethealth
@@ -17,7 +17,7 @@ ARG BUILD_VERSION
 ARG RIGGING_IMAGE
 
 FROM $BUILD_IMAGE as build
-RUN apt-get update && apt-get install -y libcap2-bin && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN set -ex && apt-get update && apt-get install -y libcap2-bin && apt-get clean && rm -rf /var/lib/apt/lists/*
 ADD ./ /go/src/github.com/gravitational/satellite/
 RUN cd /go/src/github.com/gravitational/satellite/ && BUILD_VERSION=${BUILD_VERSION} go run mage.go build:nethealth
 

--- a/Dockerfile.nethealth
+++ b/Dockerfile.nethealth
@@ -17,16 +17,22 @@ ARG BUILD_VERSION
 ARG RIGGING_IMAGE
 
 FROM $BUILD_IMAGE as build
+RUN apt-get update && apt-get install -y libcap2-bin && apt-get clean && rm -rf /var/lib/apt/lists/*
 ADD ./ /go/src/github.com/gravitational/satellite/
 RUN cd /go/src/github.com/gravitational/satellite/ && BUILD_VERSION=${BUILD_VERSION} go run mage.go build:nethealth
+
 
 #
 # Build nethealth container
 #
 FROM ${BASE_IMAGE}
-RUN apt-get update && apt-get install -y libcap2-bin && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /sbin/getcap /sbin
+COPY --from=build /sbin/setcap /sbin
+COPY --from=build /lib/x86_64-linux-gnu/libcap.so.2 /lib
 
 COPY --from=build /go/src/github.com/gravitational/satellite/build/nethealth /nethealth
 
-RUN /sbin/setcap 'cap_net_raw=+ep' /nethealth
+RUN ["/sbin/setcap", "cap_net_raw=+ep", "/nethealth"]
+
 CMD ["/nethealth"]  

--- a/Dockerfile.nethealth
+++ b/Dockerfile.nethealth
@@ -17,22 +17,12 @@ ARG BUILD_VERSION
 ARG RIGGING_IMAGE
 
 FROM $BUILD_IMAGE as build
-RUN set -ex && apt-get update && apt-get install -y libcap2-bin && apt-get clean && rm -rf /var/lib/apt/lists/*
 ADD ./ /go/src/github.com/gravitational/satellite/
 RUN cd /go/src/github.com/gravitational/satellite/ && BUILD_VERSION=${BUILD_VERSION} go run mage.go build:nethealth
-
 
 #
 # Build nethealth container
 #
 FROM ${BASE_IMAGE}
-
-COPY --from=build /sbin/getcap /sbin
-COPY --from=build /sbin/setcap /sbin
-COPY --from=build /lib/x86_64-linux-gnu/libcap.so.2 /lib
-
 COPY --from=build /go/src/github.com/gravitational/satellite/build/nethealth /nethealth
-
-RUN ["/sbin/setcap", "cap_net_raw=+ep", "/nethealth"]
-
 CMD ["/nethealth"]  

--- a/build.go
+++ b/build.go
@@ -39,7 +39,7 @@ var (
 	nethealthRegistryImage = env("NETHEALTH_REGISTRY_IMAGE", "quay.io/gravitational/nethealth-dev")
 
 	// baseImage is the base OS image to use for containers
-	baseImage = "ubuntu:19.10"
+	baseImage = "gcr.io/distroless/base-debian10"
 
 	// buildVersion allows override of the version string from env variable
 	buildVersion = env("BUILD_VERSION", "")


### PR DESCRIPTION
### Description
This PR replaces the ubuntu 19.10 base image used when building the nethealth image with a distroless base image.

### Purpose
Security scans for the nethealth images built on top of ubuntu 19.10 are reporting some vulnerabilities. Moving to distroless can help reduce these vulnerabilities. Though it looks like quay does not currently support security scans for distroless images.