### PR TITLE
Update mock client implementation

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -838,6 +838,14 @@ func (r *mockClient) UpdateTimeline(ctx context.Context, req *pb.UpdateRequest) 
 	return &pb.UpdateResponse{}, nil
 }
 
+// UpdateLocalTimeline requests to update the local timeline with a new event.
+func (r *mockClient) UpdateLocalTimeline(ctx context.Context, req *pb.UpdateRequest) (*pb.UpdateResponse, error) {
+	if err := r.agent.RecordLocalEvents(ctx, []*pb.TimelineEvent{req.GetEvent()}); err != nil {
+		return nil, GRPCError(err)
+	}
+	return &pb.UpdateResponse{}, nil
+}
+
 // Close closes the RPC client connection.
 func (r *mockClient) Close() error {
 	return nil

--- a/monitoring/timedrift_test.go
+++ b/monitoring/timedrift_test.go
@@ -181,6 +181,11 @@ func (a *mockedTimeAgentClient) UpdateTimeline(ctx context.Context,
 	return nil, nil
 }
 
+func (a *mockedTimeAgentClient) UpdateLocalTimeline(ctx context.Context,
+	req *agentpb.UpdateRequest) (*agentpb.UpdateResponse, error) {
+	return nil, nil
+}
+
 func (a *mockedTimeAgentClient) Close() error {
 	return nil
 }


### PR DESCRIPTION
### Description
This PR just updates the mock client implementations used in unit tests. I previously updated the `Client` interface in https://github.com/gravitational/satellite/pull/199, but I forgot to update the mock clients.