### PR TITLE
[7.0.x] Edit probe format (#205)

### DIFF
--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -309,8 +309,9 @@ func (c *nethealthChecker) isHealthy(peer string) (healthy bool, err error) {
 func nethealthFailureProbe(name, peer string, packetLoss float64) *pb.Probe {
 	return &pb.Probe{
 		Checker: name,
-		Detail: fmt.Sprintf("overlay packet loss for node %s is higher than the allowed threshold of %d%%: %d%%",
-			peer, int(thresholdPercent), int(packetLoss*100)),
+		Detail: fmt.Sprintf("overlay packet loss for node %s is higher than the allowed threshold of %d%%",
+			peer, int(thresholdPercent)),
+		Error:    fmt.Sprintf("current packet loss at %d%%", int(100*packetLoss)),
 		Status:   pb.Probe_Failed,
 		Severity: pb.Probe_Warning,
 	}


### PR DESCRIPTION
### Description
The current format of the failed probe for nethealth checks is bit off and might be unclear on first glance what the error is. This PR updates the format and clarifies the error message.

### Linked tickets and other PRs
* Port https://github.com/gravitational/satellite/pull/205