### PR TITLE
[7.0.x] Query members before running nethealth check (#204)

### DIFF
--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -126,6 +126,15 @@ func (c *nethealthChecker) Check(ctx context.Context, reporter health.Reporter) 
 }
 
 func (c *nethealthChecker) check(ctx context.Context, reporter health.Reporter) error {
+	peers, err := c.getPeers()
+	if err != nil {
+		log.Debug("Failed to discover nethealth peers: %v.", err)
+		return nil
+	}
+	if len(peers) == 0 {
+		return nil
+	}
+
 	addr, err := c.getNethealthAddr()
 	if trace.IsNotFound(err) {
 		log.Debug("Nethealth pod was not found.")
@@ -148,18 +157,28 @@ func (c *nethealthChecker) check(ctx context.Context, reporter health.Reporter) 
 		return nil
 	}
 
-	netData, err = c.filterNetData(netData)
-	if err != nil {
-		log.WithError(err).Error("Failed to filter nethealth data.")
-		return nil
-	}
-
-	updated, err := c.updateStats(netData)
+	updated, err := c.updateStats(filterByK8s(netData, peers))
 	if err != nil {
 		return trace.Wrap(err, "failed to update nethealth stats")
 	}
 
 	return c.verifyNethealth(updated, reporter)
+}
+
+// getPeers returns all nethealth peers as a list of strings.
+func (c *nethealthChecker) getPeers() (peers []string, err error) {
+	opts := metav1.ListOptions{
+		LabelSelector: nethealthLabelSelector.String(),
+		FieldSelector: fields.OneTermNotEqualSelector("spec.nodeName", c.NodeName).String(),
+	}
+	pods, err := c.Client.CoreV1().Pods(nethealthNamespace).List(opts)
+	if err != nil {
+		return peers, utils.ConvertError(err)
+	}
+	for _, pod := range pods.Items {
+		peers = append(peers, pod.Spec.NodeName)
+	}
+	return peers, nil
 }
 
 // getNethealthAddr returns the address of the local nethealth pod.
@@ -416,32 +435,19 @@ func getPeerName(labels []*dto.LabelPair) (peer string, err error) {
 	return "", trace.NotFound("unable to find %s label", peerLabel)
 }
 
-// filterNetData filters the netData. Nethealth may retain metrics for nodes
-// that are no longer part of the cluster. Metrics for these nodes should not
-// be further processed.
-func (c *nethealthChecker) filterNetData(netData map[string]networkData) (filtered map[string]networkData, err error) {
-	nodes, err := c.Client.CoreV1().Nodes().List(metav1.ListOptions{
-		FieldSelector: fields.OneTermNotEqualSelector("metadata.name", c.NodeName).String(),
-	})
-	if err != nil {
-		return filtered, trace.Wrap(err)
-	}
-	return filterByK8s(netData, nodes.Items)
-}
-
 // filterByK8s removes netData for nodes that are no longer members of the
 // kubernetes cluster.
-func filterByK8s(netData map[string]networkData, nodes []corev1.Node) (filtered map[string]networkData, err error) {
+func filterByK8s(netData map[string]networkData, nodes []string) (filtered map[string]networkData) {
 	filtered = make(map[string]networkData)
 	for _, node := range nodes {
-		data, exists := netData[node.Name]
+		data, exists := netData[node]
 		if !exists {
-			log.WithField("node", node.Name).Warn("Missing nethealth data for peer.")
+			log.WithField("node", node).Warn("Missing nethealth data for node.")
 			continue
 		}
-		filtered[node.Name] = data
+		filtered[node] = data
 	}
-	return filtered, nil
+	return filtered
 }
 
 // netStats holds nethealth data for a peer.

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -128,7 +128,7 @@ func (c *nethealthChecker) Check(ctx context.Context, reporter health.Reporter) 
 func (c *nethealthChecker) check(ctx context.Context, reporter health.Reporter) error {
 	peers, err := c.getPeers()
 	if err != nil {
-		log.Debug("Failed to discover nethealth peers: %v.", err)
+		log.Debugf("Failed to discover nethealth peers: %v.", err)
 		return nil
 	}
 	if len(peers) == 0 {

--- a/monitoring/nethealth_test.go
+++ b/monitoring/nethealth_test.go
@@ -289,7 +289,7 @@ func (s *NethealthSuite) TestFilterByK8s(c *C) {
 		comment  CommentInterface
 		expected map[string]networkData
 		netData  map[string]networkData
-		nodes    []corev1.Node
+		nodes    []string
 	}{
 		{
 			comment: Commentf("Expected original data set."),
@@ -299,8 +299,8 @@ func (s *NethealthSuite) TestFilterByK8s(c *C) {
 			netData: map[string]networkData{
 				"node-1": {},
 			},
-			nodes: []corev1.Node{
-				s.newTestNode("node-1"),
+			nodes: []string{
+				"node-1",
 			},
 		},
 		{
@@ -321,16 +321,15 @@ func (s *NethealthSuite) TestFilterByK8s(c *C) {
 				"node-2": {},
 				"node-3": {},
 			},
-			nodes: []corev1.Node{
-				s.newTestNode("node-1"),
-				s.newTestNode("node-2"),
+			nodes: []string{
+				"node-1",
+				"node-2",
 			},
 		},
 	}
 
 	for _, testCase := range testCases {
-		netData, err := filterByK8s(testCase.netData, testCase.nodes)
-		c.Assert(err, IsNil, testCase.comment)
+		netData := filterByK8s(testCase.netData, testCase.nodes)
 		c.Assert(netData, test.DeepCompare, testCase.expected, testCase.comment)
 	}
 }


### PR DESCRIPTION
### Description
On a single node cluster, the logs are spammed with `Original Error: *trace.NotFoundError nethealth_echo_request_total metrics not found ...` messages. This is because the current impl expects nethealth nethealth request/timeout counters to be present in the incoming metrics. For a single node cluster, no counters should be initialized.

This single node scenario should be expected and handled without logging an error.

### Linked tickets and other PRs
* Port https://github.com/gravitational/satellite/pull/204