### PR TITLE
Fix health check behavior during cluster modification

### DIFF
--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -111,14 +111,7 @@ func (c *nethealthChecker) Name() string {
 func (c *nethealthChecker) Check(ctx context.Context, reporter health.Reporter) {
 	err := c.check(ctx, reporter)
 	if err != nil {
-		log.WithError(err).Warn("Failed to verify nethealth")
-		reporter.Add(&pb.Probe{
-			Checker:  c.Name(),
-			Detail:   "failed to verify nethealth",
-			Error:    trace.UserMessage(err),
-			Status:   pb.Probe_Failed,
-			Severity: pb.Probe_Warning,
-		})
+		log.WithError(err).Debug("Failed to verify nethealth.")
 		return
 	}
 	if reporter.NumProbes() == 0 {

--- a/monitoring/ping.go
+++ b/monitoring/ping.go
@@ -290,9 +290,10 @@ func (c *pingChecker) calculateRTT(serfClient agent.SerfClient, self, node serf.
 func (c *pingChecker) failureProbe(node string, latency int64) *pb.Probe {
 	return &pb.Probe{
 		Checker: c.Name(),
-		Detail: fmt.Sprintf("ping between %s and %s is higher than the allowed threshold of %dns",
-			c.self.Name, node, latencyThreshold.Nanoseconds()),
-		Error:  fmt.Sprintf("ping latency at %dns", latency),
-		Status: pb.Probe_Failed,
+		Detail: fmt.Sprintf("ping between %s and %s is higher than the allowed threshold of %dms",
+			c.self.Name, node, latencyThreshold.Milliseconds()),
+		Error:    fmt.Sprintf("ping latency at %dms", (latency / int64(time.Millisecond/time.Nanosecond))),
+		Status:   pb.Probe_Failed,
+		Severity: pb.Probe_Warning,
 	}
 }

--- a/monitoring/ping.go
+++ b/monitoring/ping.go
@@ -18,6 +18,7 @@ package monitoring
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -132,44 +133,36 @@ func (c *pingChecker) Name() string {
 // desired threshold
 // Implements health.Checker
 func (c *pingChecker) Check(ctx context.Context, r health.Reporter) {
-	probeSeverity, err := c.check(ctx, r)
-
-	if err != nil {
-		c.logger.Error(err.Error())
-		r.Add(NewProbeFromErr(c.Name(), "", err))
+	if err := c.check(ctx, r); err != nil {
+		c.logger.WithError(err).Debug("Failed to verify ping latency.")
 		return
 	}
-	r.Add(&pb.Probe{
-		Checker:  c.Name(),
-		Status:   pb.Probe_Running,
-		Severity: probeSeverity,
-	})
+	if r.NumProbes() == 0 {
+		r.Add(NewSuccessProbe(c.Name()))
+	}
 }
 
 // check runs the actual system status verification code and returns an error
 // in case issues arise in the process
-func (c *pingChecker) check(ctx context.Context, r health.Reporter) (probeSeverity pb.Probe_Severity, err error) {
-
+func (c *pingChecker) check(_ context.Context, r health.Reporter) (err error) {
 	client := c.serfClient
 
 	nodes, err := client.Members()
 	if err != nil {
-		return pb.Probe_None, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 
-	probeSeverity, err = c.checkNodesRTT(nodes, client)
-	if err != nil {
-		return pb.Probe_None, trace.Wrap(err)
+	if err = c.checkNodesRTT(nodes, client, r); err != nil {
+		return trace.Wrap(err)
 	}
 
-	return probeSeverity, nil
+	return nil
 }
 
 // checkNodesRTT implements the bulk of the logic by checking the ping time
 // between this node (self) and the other Serf Cluster member nodes
-func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient) (probeSeverity pb.Probe_Severity, err error) {
-	probeSeverity = pb.Probe_None
-
+func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient,
+	reporter health.Reporter) (err error) {
 	// ping each other node and raise a warning in case the results are over
 	// a specified threshold
 	for _, node := range nodes {
@@ -187,17 +180,17 @@ func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient
 
 		rttNanoSec, err := c.calculateRTT(client, c.self, node)
 		if err != nil {
-			return probeSeverity, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 
 		latencies, err := c.saveLatencyStats(rttNanoSec, node)
 		if err != nil {
-			return probeSeverity, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 
 		latencyHistogram, err := c.buildLatencyHistogram(node.Name, latencies)
 		if err != nil {
-			return probeSeverity, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 
 		c.logger.Debugf("%s <-ping-> %s = %dns [latest]", c.self.Name, node.Name, rttNanoSec)
@@ -211,7 +204,7 @@ func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient
 			c.logger.Warningf("%s <-ping-> %s = slow ping detected. Value %dns over threshold %s (%dns)",
 				c.self.Name, node.Name, latencyPercentile,
 				latencyThreshold.String(), latencyThreshold.Nanoseconds())
-			probeSeverity = pb.Probe_Warning
+			reporter.Add(c.failureProbe(node.Name, latencyPercentile))
 		} else {
 			c.logger.Debugf("%s <-ping-> %s = ping okay. Value %dns within threshold %s (%dns)",
 				c.self.Name, node.Name, latencyPercentile,
@@ -219,7 +212,7 @@ func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient
 		}
 	}
 
-	return probeSeverity, nil
+	return nil
 }
 
 // buildLatencyHistogram maps latencies to a HDRHistrogram
@@ -290,4 +283,16 @@ func (c *pingChecker) calculateRTT(serfClient agent.SerfClient, self, node serf.
 		latency,
 		otherNodeCoord.Vec, otherNodeCoord.Error, otherNodeCoord.Height, otherNodeCoord.Adjustment)
 	return latency, nil
+}
+
+// failureProbe constructs a new probe that represents a failed ping check
+// against the specified node.
+func (c *pingChecker) failureProbe(node string, latency int64) *pb.Probe {
+	return &pb.Probe{
+		Checker: c.Name(),
+		Detail: fmt.Sprintf("ping between %s and %s is higher than the allowed threshold of %dns",
+			c.self.Name, node, latencyThreshold.Nanoseconds()),
+		Error:  fmt.Sprintf("ping latency at %dns", latency),
+		Status: pb.Probe_Failed,
+	}
 }

--- a/monitoring/ping.go
+++ b/monitoring/ping.go
@@ -292,7 +292,7 @@ func (c *pingChecker) failureProbe(node string, latency int64) *pb.Probe {
 		Checker: c.Name(),
 		Detail: fmt.Sprintf("ping between %s and %s is higher than the allowed threshold of %dms",
 			c.self.Name, node, latencyThreshold.Milliseconds()),
-		Error:    fmt.Sprintf("ping latency at %dms", (latency / int64(time.Millisecond/time.Nanosecond))),
+		Error:    fmt.Sprintf("ping latency at %dms", (latency / int64(time.Millisecond))),
 		Status:   pb.Probe_Failed,
 		Severity: pb.Probe_Warning,
 	}

--- a/monitoring/ping_test.go
+++ b/monitoring/ping_test.go
@@ -78,7 +78,7 @@ func (*PingSuite) TestPingChecker(c *check.C) {
 				},
 			},
 			Coords:      map[string]*coordinate.Coordinate{},
-			Status:      agentpb.NodeStatus_Degraded,
+			Status:      agentpb.NodeStatus_Running,
 			Description: "Testing missing coordinates for cluster members",
 		},
 		{


### PR DESCRIPTION
### Description
This PR modifies a few health checks (`timedrift`, `nethealth`, `ping`). These healtch checks will no longer report a failed probe if the check does not run to completion.

- The `timedrift` check will no longer report a failed probe in situations described in https://github.com/gravitational/gravity/issues/1595.
- The `nethealth` check will no longer report a failed probe if the `kube-apiserver` is down. This scenario doesn't necessarily indicate a overlay network issue and instead just adds noise to the status.
- The `ping` check will no longer report a failed probe if coordinates are not found.

### Linked tickets and other PRs
* Updates https://github.com/gravitational/gravity/issues/1595, https://github.com/gravitational/gravity/issues/1552

### Testing done
**Verify modified health checks still report success probes**

**Verify `timedrift` is still detected.**
- Running a local cluster on VMs. We can create time drift by suspending a VM and resuming after some time.
- Should remote access go offline if timedrift is high?
```
[vagrant@node-1 ~]$ sudo gravity status
Cluster name:           dev.test
Cluster status:         degraded
Cluster image:          telekube, version 7.0.5
Gravity version:        7.0.5 (client) / 7.0.5 (server)
[...]
Cluster nodes:
    Masters:
        * node-2 / 172.28.128.102 / node
            Status:             degraded
            [×]                 time drift between 172.28.128.102 and 172.28.128.103 is higher than the allowed threshold of 300ms: -1m42.871109596s
            Remote access:      online
        * node-3 / 172.28.128.103 / node
            Status:             degraded
            [×]                 time drift between 172.28.128.103 and 172.28.128.101 is higher than the allowed threshold of 300ms: 1m42.90854089s
            [×]                 time drift between 172.28.128.103 and 172.28.128.102 is higher than the allowed threshold of 300ms: 1m42.86881878s
            Remote access:      offline
        * node-1 / 172.28.128.101 / node
            Status:             degraded
            [×]                 time drift between 172.28.128.101 and 172.28.128.103 is higher than the allowed threshold of 300ms: -1m42.908975939s
            Remote access:      online
[ERROR]: degraded
```

**Verify nethealth still detects blocked udp.**
```
[vagrant@node-1 ~]$ sudo iptables -A INPUT -p udp -s 172.28.128.102 -j DROP
[vagrant@node-1 ~]$ sudo gravity status
Cluster name:           dev.test
Cluster status:         active
Cluster image:          telekube, version 7.0.5
Gravity version:        7.0.5 (client) / 7.0.5 (server)
[...]
Cluster nodes:
    Masters:
        * node-2 / 172.28.128.102 / node
            Status:             healthy
            [!]                 overlay packet loss for node 172.28.128.101 is higher than the allowed threshold of 20% (current packet loss at 100%)
            Remote access:      online
        * node-3 / 172.28.128.103 / node
            Status:             healthy
            Remote access:      online
        * node-1 / 172.28.128.101 / node
            Status:             healthy
            [!]                 overlay packet loss for node 172.28.128.102 is higher than the allowed threshold of 20% (current packet loss at 100%)
            Remote access:      online
```

**Verify high ping latency is still detected**
- Use `tc` to simulate high latency (30ms) and verify ping check reports warning.
```
[vagrant@node-1 ~]$ sudo gravity status
Cluster name:           dev.test
Cluster status:         active
Cluster image:          telekube, version 7.0.5
Gravity version:        7.0.5 (client) / 7.0.5 (server)
[...]
Cluster nodes:
    Masters:
        * node-2 / 172.28.128.102 / node
            Status:             healthy
            [!]                 ping between 172_28_128_102.dev.test and 172_28_128_101.dev.test is higher than the allowed threshold of 15ms (ping latency at 33ms)
            Remote access:      online
        * node-3 / 172.28.128.103 / node
            Status:             healthy
            [!]                 ping between 172_28_128_103.dev.test and 172_28_128_101.dev.test is higher than the allowed threshold of 15ms (ping latency at 31ms)
            Remote access:      online
        * node-1 / 172.28.128.101 / node
            Status:             healthy
            [!]                 ping between 172_28_128_101.dev.test and 172_28_128_103.dev.test is higher than the allowed threshold of 15ms (ping latency at 31ms)
            [!]                 ping between 172_28_128_101.dev.test and 172_28_128_102.dev.test is higher than the allowed threshold of 15ms (ping latency at 33ms)
            Remote access:      online
```