### PR TITLE
[6.1.x] Fix health check behavior during cluster modification (#213)

### DIFF
--- a/agent/proto/agentpb/suite_test.go
+++ b/agent/proto/agentpb/suite_test.go
@@ -24,14 +24,14 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func init() {
+func TestSuite(t *testing.T) { TestingT(t) }
+
+func (s *ProtoSuite) SetUpSuite(c *C) {
 	if testing.Verbose() {
 		log.SetOutput(os.Stderr)
 		log.SetLevel(log.InfoLevel)
 	}
 }
-
-func TestSuite(t *testing.T) { TestingT(t) }
 
 type ProtoSuite struct{}
 

--- a/build.go
+++ b/build.go
@@ -29,11 +29,11 @@ import (
 
 var (
 	// buildContainer is a docker container used to build go binaries
-	buildContainer = "golang:1.12.0"
+	buildContainer = "golang:1.14.3"
 
 	// golangciVersion is the version of golangci-lint to use for linting
 	// https://github.com/golangci/golangci-lint/releases
-	golangciVersion = "v1.15.0"
+	golangciVersion = "v1.27.0"
 
 	// nethealthRegistryImage is the docker tag to use to push the nethealth container to the requested registry
 	nethealthRegistryImage = env("NETHEALTH_REGISTRY_IMAGE", "quay.io/gravitational/nethealth-dev")
@@ -194,9 +194,8 @@ func (Test) Lint() error {
 		fmt.Sprintf("--volume=%v:/go/src/github.com/gravitational/satellite", srcDir()),
 		`--env="GOCACHE=/go/src/github.com/gravitational/satellite/build/cache/go"`,
 		fmt.Sprint("satellite-build:", version()),
-		"bash", "-c",
-		"cd /go/src/github.com/gravitational/satellite; golangci-lint run -n --deadline=30m --enable-all"+
-			" -D gochecknoglobals -D gochecknoinits",
+		"golangci-lint", "run", "--new", "--deadline=30m", "--enable-all",
+		"--disable=gochecknoglobals", "--disable=gochecknoinits", "--disable=gomodguard",
 	))
 }
 

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -110,14 +110,7 @@ func (c *nethealthChecker) Name() string {
 func (c *nethealthChecker) Check(ctx context.Context, reporter health.Reporter) {
 	err := c.check(ctx, reporter)
 	if err != nil {
-		log.WithError(err).Warn("Failed to verify nethealth")
-		reporter.Add(&pb.Probe{
-			Checker:  c.Name(),
-			Detail:   "failed to verify nethealth",
-			Error:    trace.UserMessage(err),
-			Status:   pb.Probe_Failed,
-			Severity: pb.Probe_Warning,
-		})
+		log.WithError(err).Debug("Failed to verify nethealth.")
 		return
 	}
 	if reporter.NumProbes() == 0 {

--- a/monitoring/ping.go
+++ b/monitoring/ping.go
@@ -18,6 +18,7 @@ package monitoring
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -135,44 +136,36 @@ func (c *pingChecker) Name() string {
 // desired threshold
 // Implements health.Checker
 func (c *pingChecker) Check(ctx context.Context, r health.Reporter) {
-	probeSeverity, err := c.check(ctx, r)
-
-	if err != nil {
-		c.logger.Error(err.Error())
-		r.Add(NewProbeFromErr(c.Name(), "", err))
+	if err := c.check(ctx, r); err != nil {
+		c.logger.WithError(err).Debug("Failed to verify ping latency.")
 		return
 	}
-	r.Add(&pb.Probe{
-		Checker:  c.Name(),
-		Status:   pb.Probe_Running,
-		Severity: probeSeverity,
-	})
+	if r.NumProbes() == 0 {
+		r.Add(NewSuccessProbe(c.Name()))
+	}
 }
 
 // check runs the actual system status verification code and returns an error
 // in case issues arise in the process
-func (c *pingChecker) check(ctx context.Context, r health.Reporter) (probeSeverity pb.Probe_Severity, err error) {
-
+func (c *pingChecker) check(_ context.Context, r health.Reporter) (err error) {
 	client := c.serfClient
 
 	nodes, err := client.Members()
 	if err != nil {
-		return pb.Probe_None, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 
-	probeSeverity, err = c.checkNodesRTT(nodes, client)
-	if err != nil {
-		return pb.Probe_None, trace.Wrap(err)
+	if err = c.checkNodesRTT(nodes, client, r); err != nil {
+		return trace.Wrap(err)
 	}
 
-	return probeSeverity, nil
+	return nil
 }
 
 // checkNodesRTT implements the bulk of the logic by checking the ping time
 // between this node (self) and the other Serf Cluster member nodes
-func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient) (probeSeverity pb.Probe_Severity, err error) {
-	probeSeverity = pb.Probe_None
-
+func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient,
+	reporter health.Reporter) (err error) {
 	// ping each other node and raise a warning in case the results are over
 	// a specified threshold
 	for _, node := range nodes {
@@ -190,17 +183,17 @@ func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient
 
 		rttNanoSec, err := c.calculateRTT(client, c.self, node)
 		if err != nil {
-			return probeSeverity, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 
 		latencies, err := c.saveLatencyStats(rttNanoSec, node)
 		if err != nil {
-			return probeSeverity, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 
 		latencyHistogram, err := c.buildLatencyHistogram(node.Name, latencies)
 		if err != nil {
-			return probeSeverity, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 
 		c.logger.Debugf("%s <-ping-> %s = %dns [latest]", c.self.Name, node.Name, rttNanoSec)
@@ -214,7 +207,7 @@ func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient
 			c.logger.Warningf("%s <-ping-> %s = slow ping detected. Value %dns over threshold %s (%dns)",
 				c.self.Name, node.Name, latencyPercentile,
 				latencyThreshold.String(), latencyThreshold.Nanoseconds())
-			probeSeverity = pb.Probe_Warning
+			reporter.Add(c.failureProbe(node.Name, latencyPercentile))
 		} else {
 			c.logger.Debugf("%s <-ping-> %s = ping okay. Value %dns within threshold %s (%dns)",
 				c.self.Name, node.Name, latencyPercentile,
@@ -222,7 +215,7 @@ func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient
 		}
 	}
 
-	return probeSeverity, nil
+	return nil
 }
 
 // buildLatencyHistogram maps latencies to a HDRHistrogram
@@ -293,4 +286,17 @@ func (c *pingChecker) calculateRTT(serfClient agent.SerfClient, self, node serf.
 		latency,
 		otherNodeCoord.Vec, otherNodeCoord.Error, otherNodeCoord.Height, otherNodeCoord.Adjustment)
 	return latency, nil
+}
+
+// failureProbe constructs a new probe that represents a failed ping check
+// against the specified node.
+func (c *pingChecker) failureProbe(node string, latency int64) *pb.Probe {
+	return &pb.Probe{
+		Checker: c.Name(),
+		Detail: fmt.Sprintf("ping between %s and %s is higher than the allowed threshold of %dms",
+			c.self.Name, node, latencyThreshold.Milliseconds()),
+		Error:    fmt.Sprintf("ping latency at %dms", (latency / int64(time.Millisecond))),
+		Status:   pb.Probe_Failed,
+		Severity: pb.Probe_Warning,
+	}
 }

--- a/monitoring/ping.go
+++ b/monitoring/ping.go
@@ -196,22 +196,22 @@ func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient
 			return trace.Wrap(err)
 		}
 
-		c.logger.Debugf("%s <-ping-> %s = %dns [latest]", c.self.Name, node.Name, rttNanoSec)
-		c.logger.Debugf("%s <-ping-> %s = %dns [%.2f percentile]",
+		latency95 := time.Duration(latencyHistogram.ValueAtQuantile(latencyQuantile))
+
+		c.logger.Debugf("%s <-ping-> %s = %dms [latest]",
+			c.self.Name, node.Name, (rttNanoSec / int64(time.Millisecond)))
+		c.logger.Debugf("%s <-ping-> %s = %dms [%.2f percentile]",
 			c.self.Name, node.Name,
-			latencyHistogram.ValueAtQuantile(latencyQuantile),
+			latency95.Milliseconds(),
 			latencyQuantile)
 
-		latencyPercentile := latencyHistogram.ValueAtQuantile(latencyQuantile)
-		if latencyPercentile >= latencyThreshold.Nanoseconds() {
-			c.logger.Warningf("%s <-ping-> %s = slow ping detected. Value %dns over threshold %s (%dns)",
-				c.self.Name, node.Name, latencyPercentile,
-				latencyThreshold.String(), latencyThreshold.Nanoseconds())
-			reporter.Add(c.failureProbe(node.Name, latencyPercentile))
+		if latency95 >= latencyThreshold {
+			c.logger.Warningf("%s <-ping-> %s = slow ping detected. Value %dms over threshold %dms",
+				c.self.Name, node.Name, latency95.Milliseconds(), latencyThreshold.Milliseconds())
+			reporter.Add(c.failureProbe(node.Name, latency95))
 		} else {
-			c.logger.Debugf("%s <-ping-> %s = ping okay. Value %dns within threshold %s (%dns)",
-				c.self.Name, node.Name, latencyPercentile,
-				latencyThreshold.String(), latencyThreshold.Nanoseconds())
+			c.logger.Debugf("%s <-ping-> %s = ping okay. Value %dms within threshold %dms",
+				c.self.Name, node.Name, latency95.Milliseconds(), latencyThreshold.Milliseconds())
 		}
 	}
 
@@ -290,12 +290,12 @@ func (c *pingChecker) calculateRTT(serfClient agent.SerfClient, self, node serf.
 
 // failureProbe constructs a new probe that represents a failed ping check
 // against the specified node.
-func (c *pingChecker) failureProbe(node string, latency int64) *pb.Probe {
+func (c *pingChecker) failureProbe(node string, latency time.Duration) *pb.Probe {
 	return &pb.Probe{
 		Checker: c.Name(),
 		Detail: fmt.Sprintf("ping between %s and %s is higher than the allowed threshold of %dms",
 			c.self.Name, node, latencyThreshold.Milliseconds()),
-		Error:    fmt.Sprintf("ping latency at %dms", (latency / int64(time.Millisecond))),
+		Error:    fmt.Sprintf("ping latency at %dms", latency.Milliseconds()),
 		Status:   pb.Probe_Failed,
 		Severity: pb.Probe_Warning,
 	}

--- a/monitoring/ping_test.go
+++ b/monitoring/ping_test.go
@@ -78,7 +78,7 @@ func (*PingSuite) TestPingChecker(c *check.C) {
 				},
 			},
 			Coords:      map[string]*coordinate.Coordinate{},
-			Status:      agentpb.NodeStatus_Degraded,
+			Status:      agentpb.NodeStatus_Running,
 			Description: "Testing missing coordinates for cluster members",
 		},
 		{


### PR DESCRIPTION
### Description
This PR modifies a few health checks (`timedrift`, `nethealth`, `ping`). These health checks will no longer report a failed probe if the check does not run to completion.

Also updates golang/golangci-lint versions.

### Linked tickets and other PRs
* Ports https://github.com/gravitational/satellite/pull/213, https://github.com/gravitational/satellite/pull/217