### PR TITLE
Update golangci version

### DIFF
--- a/agent/proto/agentpb/suite_test.go
+++ b/agent/proto/agentpb/suite_test.go
@@ -24,14 +24,14 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func init() {
+func TestSuite(t *testing.T) { TestingT(t) }
+
+func (s *ProtoSuite) SetUpSuite(c *C) {
 	if testing.Verbose() {
 		log.SetOutput(os.Stderr)
 		log.SetLevel(log.InfoLevel)
 	}
 }
-
-func TestSuite(t *testing.T) { TestingT(t) }
 
 type ProtoSuite struct{}
 

--- a/build.go
+++ b/build.go
@@ -29,11 +29,11 @@ import (
 
 var (
 	// buildContainer is a docker container used to build go binaries
-	buildContainer = "golang:1.12.17"
+	buildContainer = "golang:1.14.3"
 
 	// golangciVersion is the version of golangci-lint to use for linting
 	// https://github.com/golangci/golangci-lint/releases
-	golangciVersion = "v1.19.1"
+	golangciVersion = "v1.27.0"
 
 	// nethealthRegistryImage is the docker tag to use to push the nethealth container to the requested registry
 	nethealthRegistryImage = env("NETHEALTH_REGISTRY_IMAGE", "quay.io/gravitational/nethealth-dev")
@@ -195,7 +195,7 @@ func (Test) Lint() error {
 		`--env="GOCACHE=/go/src/github.com/gravitational/satellite/build/cache/go"`,
 		fmt.Sprint("satellite-build:", version()),
 		"golangci-lint", "run", "--new", "--deadline=30m", "--enable-all",
-		"--disable=gochecknoglobals", "--disable=gochecknoinits",
+		"--disable=gochecknoglobals", "--disable=gochecknoinits", "--disable=gomodguard",
 	))
 }
 


### PR DESCRIPTION
### Description
This PR updates the golangci-lint version to the latest release 1.27.0 and golang to 1.14.3.

### Purpose
The current golangci-lint/golang version used to build satellite is incorrectly labeling the `time.Durration.Milliseconds()` method as `undefined`. This PR just removes the lint warnings.
```
=====> Linting Satellite...

# github.com/gravitational/satellite/monitoring
monitoring/ping.go:294:39: latencyThreshold.Milliseconds undefined (type time.Duration has no field or method Milliseconds)
# github.com/gravitational/satellite/monitoring [github.com/gravitational/satellite/monitoring.test]
monitoring/ping.go:294:39: latencyThreshold.Milliseconds undefined (type time.Duration has no field or method Milliseconds)
```