### PR TITLE
[6.1.x] Revert golang version

### DIFF
--- a/agent/proto/agentpb/suite_test.go
+++ b/agent/proto/agentpb/suite_test.go
@@ -24,14 +24,14 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func TestSuite(t *testing.T) { TestingT(t) }
-
-func (s *ProtoSuite) SetUpSuite(c *C) {
+func init() {
 	if testing.Verbose() {
 		log.SetOutput(os.Stderr)
 		log.SetLevel(log.InfoLevel)
 	}
 }
+
+func TestSuite(t *testing.T) { TestingT(t) }
 
 type ProtoSuite struct{}
 

--- a/build.go
+++ b/build.go
@@ -29,11 +29,11 @@ import (
 
 var (
 	// buildContainer is a docker container used to build go binaries
-	buildContainer = "golang:1.14.3"
+	buildContainer = "golang:1.12.0"
 
 	// golangciVersion is the version of golangci-lint to use for linting
 	// https://github.com/golangci/golangci-lint/releases
-	golangciVersion = "v1.27.0"
+	golangciVersion = "v1.15.0"
 
 	// nethealthRegistryImage is the docker tag to use to push the nethealth container to the requested registry
 	nethealthRegistryImage = env("NETHEALTH_REGISTRY_IMAGE", "quay.io/gravitational/nethealth-dev")
@@ -194,8 +194,9 @@ func (Test) Lint() error {
 		fmt.Sprintf("--volume=%v:/go/src/github.com/gravitational/satellite", srcDir()),
 		`--env="GOCACHE=/go/src/github.com/gravitational/satellite/build/cache/go"`,
 		fmt.Sprint("satellite-build:", version()),
-		"golangci-lint", "run", "--new", "--deadline=30m", "--enable-all",
-		"--disable=gochecknoglobals", "--disable=gochecknoinits", "--disable=gomodguard",
+		"bash", "-c",
+		"cd /go/src/github.com/gravitational/satellite; golangci-lint run -n --deadline=30m --enable-all"+
+			" -D gochecknoglobals -D gochecknoinits",
 	))
 }
 

--- a/monitoring/ping.go
+++ b/monitoring/ping.go
@@ -198,20 +198,16 @@ func (c *pingChecker) checkNodesRTT(nodes []serf.Member, client agent.SerfClient
 
 		latency95 := time.Duration(latencyHistogram.ValueAtQuantile(latencyQuantile))
 
-		c.logger.Debugf("%s <-ping-> %s = %dms [latest]",
-			c.self.Name, node.Name, (rttNanoSec / int64(time.Millisecond)))
-		c.logger.Debugf("%s <-ping-> %s = %dms [%.2f percentile]",
-			c.self.Name, node.Name,
-			latency95.Milliseconds(),
-			latencyQuantile)
+		c.logger.Debugf("%s <-ping-> %s = %s [latest]", c.self.Name, node.Name, time.Duration(rttNanoSec))
+		c.logger.Debugf("%s <-ping-> %s = %s [%.2f percentile]", c.self.Name, node.Name, latency95, latencyQuantile)
 
 		if latency95 >= latencyThreshold {
-			c.logger.Warningf("%s <-ping-> %s = slow ping detected. Value %dms over threshold %dms",
-				c.self.Name, node.Name, latency95.Milliseconds(), latencyThreshold.Milliseconds())
+			c.logger.Warningf("%s <-ping-> %s = slow ping detected. Value %s over threshold %s",
+				c.self.Name, node.Name, latency95, latencyThreshold)
 			reporter.Add(c.failureProbe(node.Name, latency95))
 		} else {
-			c.logger.Debugf("%s <-ping-> %s = ping okay. Value %dms within threshold %dms",
-				c.self.Name, node.Name, latency95.Milliseconds(), latencyThreshold.Milliseconds())
+			c.logger.Debugf("%s <-ping-> %s = ping okay. Value %s within threshold %s",
+				c.self.Name, node.Name, latency95, latencyThreshold)
 		}
 	}
 
@@ -293,9 +289,9 @@ func (c *pingChecker) calculateRTT(serfClient agent.SerfClient, self, node serf.
 func (c *pingChecker) failureProbe(node string, latency time.Duration) *pb.Probe {
 	return &pb.Probe{
 		Checker: c.Name(),
-		Detail: fmt.Sprintf("ping between %s and %s is higher than the allowed threshold of %dms",
-			c.self.Name, node, latencyThreshold.Milliseconds()),
-		Error:    fmt.Sprintf("ping latency at %dms", latency.Milliseconds()),
+		Detail: fmt.Sprintf("ping between %s and %s is higher than the allowed threshold of %s",
+			c.self.Name, node, latencyThreshold),
+		Error:    fmt.Sprintf("ping latency at %s", latency),
 		Status:   pb.Probe_Failed,
 		Severity: pb.Probe_Warning,
 	}


### PR DESCRIPTION
### Description
This PR reverts golang version to 1.12.0. The ping time format is also updated. The latency times will now be output using the largest time unit without a leading 0.