### PR TITLE
Update disk check

### DIFF
--- a/monitoring/defaults.go
+++ b/monitoring/defaults.go
@@ -69,8 +69,8 @@ func GetStorageDriverBootConfigParams(drv string) health.Checker {
 
 // NewStorageChecker creates a new instance of the volume checker
 // using the specified checker as configuration
-func NewStorageChecker(config StorageConfig) health.Checker {
-	return noopChecker{}
+func NewStorageChecker(config StorageConfig) (health.Checker, error) {
+	return noopChecker{}, nil
 }
 
 // NewDNSChecker sends some default queries to monitor DNS / service discovery health

--- a/monitoring/storage.go
+++ b/monitoring/storage.go
@@ -19,6 +19,8 @@ package monitoring
 import (
 	"fmt"
 
+	"github.com/gravitational/trace"
+
 	humanize "github.com/dustin/go-humanize"
 )
 
@@ -34,13 +36,48 @@ type StorageConfig struct {
 	Filesystems []string
 	// MinFreeBytes define minimum free volume capacity
 	MinFreeBytes uint64
-	// HighWatermark is the disk occupancy percentage that is considered degrading
+	// LowWatermark is the disk occupancy percentage that will trigger a warning probe
+	LowWatermark uint
+	// HighWatermark is the disk occupancy percentage that will trigger a critical probe
 	HighWatermark uint
+}
+
+// CheckAndSetDefaults validates that this configuration is correct and sets
+// value defaults where necessary.
+func (c *StorageConfig) CheckAndSetDefaults() error {
+	var errors []error
+	if c.Path == "" {
+		errors = append(errors, trace.BadParameter("volume path must be provided"))
+	}
+
+	if c.LowWatermark > 100 {
+		errors = append(errors, trace.BadParameter("low watermark must be 0-100"))
+	}
+
+	if c.HighWatermark > 100 {
+		errors = append(errors, trace.BadParameter("high watermark must be 0-100"))
+	}
+
+	if c.LowWatermark == 0 {
+		c.LowWatermark = DefaultLowWatermark
+	}
+
+	if c.HighWatermark == 0 {
+		c.HighWatermark = DefaultHighWatermark
+	}
+
+	if c.LowWatermark > c.HighWatermark {
+		c.LowWatermark = c.HighWatermark
+	}
+
+	return trace.NewAggregate(errors...)
 }
 
 // HighWatermarkCheckerData is attached to high watermark check results
 type HighWatermarkCheckerData struct {
-	// HighWatermark is the watermark percentage value
+	// LowWatermark is the low watermark percentage value
+	LowWatermark uint `json:"low_watermark"`
+	// HighWatermark is the high watermark percentage value
 	HighWatermark uint `json:"high_watermark"`
 	// Path is the absolute path to check
 	Path string `json:"path"`
@@ -50,17 +87,31 @@ type HighWatermarkCheckerData struct {
 	AvailableBytes uint64 `json:"available_bytes"`
 }
 
-// FailureMessage returns failure watermark check message
-func (d HighWatermarkCheckerData) FailureMessage() string {
-	return fmt.Sprintf("disk utilization on %s exceeds %v percent (%s is available out of %s), see https://gravitational.com/telekube/docs/cluster/#garbage-collection",
-		d.Path, d.HighWatermark, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
+// WarningMessage returns warning watermark check message
+func (d HighWatermarkCheckerData) WarningMessage() string {
+	diskUsage := float64(d.TotalBytes-d.AvailableBytes) / float64(d.TotalBytes) * 100
+	return fmt.Sprintf("disk utilization on %s exceeds %v%%, currently at %v%% (%s is available out of %s), cluster will degrade if usage exceeds %v%%, see https://gravitational.com/gravity/docs/cluster/#garbage-collection",
+		d.Path, d.LowWatermark, diskUsage, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes), d.HighWatermark)
+}
+
+// CriticalMessage returns critical watermark check message
+func (d HighWatermarkCheckerData) CriticalMessage() string {
+	diskUsage := float64(d.TotalBytes-d.AvailableBytes) / float64(d.TotalBytes) * 100
+	return fmt.Sprintf("disk utilization on %s exceeds %v%%, currently at %v%% (%s is available out of %s), see https://gravitational.com/gravity/docs/cluster/#garbage-collection",
+		d.Path, d.HighWatermark, diskUsage, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
 }
 
 // SuccessMessage returns success watermark check message
 func (d HighWatermarkCheckerData) SuccessMessage() string {
-	return fmt.Sprintf("disk utilization on %s is below %v percent (%s is available out of %s)",
+	return fmt.Sprintf("disk utilization on %s is below %v%% (%s is available out of %s)",
 		d.Path, d.HighWatermark, humanize.Bytes(d.AvailableBytes), humanize.Bytes(d.TotalBytes))
 }
 
 // DiskSpaceCheckerID is the checker that checks disk space utilization
 const DiskSpaceCheckerID = "disk-space"
+
+// DefaultLowWatermark is the default low watermark percentage.
+const DefaultLowWatermark = 80
+
+// DefaultHighWatermark is the default high watermark percentage.
+const DefaultHighWatermark = 90

--- a/monitoring/storage_linux_test.go
+++ b/monitoring/storage_linux_test.go
@@ -105,19 +105,31 @@ func (_ *StorageSuite) TestStorage(c *C) {
 		StorageConfig: StorageConfig{
 			Path:          path.Join("/tmp", fmt.Sprintf("%d", time.Now().Unix())),
 			WillBeCreated: true,
-			HighWatermark: 40,
+			LowWatermark:  60,
+			HighWatermark: 80,
 		},
 		osInterface: testOS{mountList: mounts, bytesAvail: 2048},
-	}.probe(c, "high watermark is reached", shallFail)
+	}.probe(c, "low watermark is not reached", shallSucceed)
 
 	storageChecker{
 		StorageConfig: StorageConfig{
 			Path:          path.Join("/tmp", fmt.Sprintf("%d", time.Now().Unix())),
 			WillBeCreated: true,
+			LowWatermark:  40,
 			HighWatermark: 60,
 		},
 		osInterface: testOS{mountList: mounts, bytesAvail: 2048},
-	}.probe(c, "high watermark is not reached", shallSucceed)
+	}.probe(c, "low watermark is reached", shallFail)
+
+	storageChecker{
+		StorageConfig: StorageConfig{
+			Path:          path.Join("/tmp", fmt.Sprintf("%d", time.Now().Unix())),
+			WillBeCreated: true,
+			LowWatermark:  20,
+			HighWatermark: 40,
+		},
+		osInterface: testOS{mountList: mounts, bytesAvail: 2048},
+	}.probe(c, "high watermark is reached", shallFail)
 }
 
 func (_ *StorageSuite) TestMatchesFilesystem(c *C) {


### PR DESCRIPTION
### Description
This PR updates the disk check and addresses items 1-3 of https://github.com/gravitational/gravity/issues/1662. The disk/storage check will now report a warning or a critical probe at different thresholds. The default is set to 80% disk usage for a warning probe and 90% disk usage for a critical probe. 

### Linked tickets and PRs
* Updates https://github.com/gravitational/gravity/issues/1662

### Testing done
Testing done on version 5.5.47. `fallocate` is a quick way to alloate disk space for a file.

**Verify warning when disk usage > 80%**
```
[vagrant@node-1 gravity]$ df
Filesystem     1K-blocks     Used Available Use% Mounted on
[...]
/dev/sdb1       25670884 20356768   3987064  84% /var/lib/gravity

[vagrant@node-1 gravity]$ sudo gravity status
[...]
Cluster nodes:
    Masters:
        * node-1 (172.28.128.101, node)
            Status:             healthy
            [!]                 disk utilization on /var/lib/gravity exceeds 80 percent (4.1GB is available out of 26GB), see https://gravitational.com/telekube/docs/cluster/#garbage-collection
            Remote access:      online
[...]
```

**Verify critical when disk usage > 90%**
```
[vagrant@node-1 gravity]$ df
Filesystem     1K-blocks     Used Available Use% Mounted on
[...]
/dev/sdb1       25670884 22229512   2114320  92% /var/lib/gravity

[vagrant@node-1 gravity]$ sudo gravity status
[...]
Cluster nodes:
    Masters:
        * node-1 (172.28.128.101, node)
            Status:             degraded
            [×]                 disk utilization on /var/lib/gravity exceeds 90 percent (2.2GB is available out of 26GB), see https://gravitational.com/telekube/docs/cluster/#garbage-collection
            Remote access:      online
[...]
```
