### PR TITLE
[5.5.x] Update default NewStorageChecker

### DIFF
--- a/monitoring/defaults.go
+++ b/monitoring/defaults.go
@@ -69,8 +69,8 @@ func GetStorageDriverBootConfigParams(drv string) health.Checker {
 
 // NewStorageChecker creates a new instance of the volume checker
 // using the specified checker as configuration
-func NewStorageChecker(config StorageConfig) health.Checker {
-	return noopChecker{}
+func NewStorageChecker(config StorageConfig) (health.Checker, error) {
+	return noopChecker{}, nil
 }
 
 // NewDNSChecker sends some default queries to monitor DNS / service discovery health


### PR DESCRIPTION
### Description
Update default NewStorageChecker return values. This fixes mac builds.