### PR TITLE
[7.0.x] Edit time-drift check behavior

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -607,7 +607,7 @@ L:
 			log.Debugf("Retrieved status from %v: %v.", status.member, status.NodeStatus)
 			nodeStatus := status.NodeStatus
 			if status.err != nil {
-				log.Warnf("Failed to query node %s(%v) status: %v.",
+				log.Debugf("Failed to query node %s(%v) status: %v.",
 					status.member.Name(), status.member.Addr(), status.err)
 				nodeStatus = unknownNodeStatus(status.member)
 			}
@@ -691,7 +691,7 @@ func (r *agent) notifyMasters(ctx context.Context) error {
 			continue
 		}
 		if err := r.notifyMaster(ctx, member, events); err != nil {
-			log.WithError(err).Warnf("Failed to notify %s of new timeline events.", member.Name())
+			log.WithError(err).Debugf("Failed to notify %s of new timeline events.", member.Name())
 		}
 	}
 

--- a/monitoring/fs_linux.go
+++ b/monitoring/fs_linux.go
@@ -75,7 +75,7 @@ func (r dtypeChecker) check(ctx context.Context, reporter health.Reporter) error
 	reporter.Add(&pb.Probe{
 		Checker: r.Name(),
 		Detail: fmt.Sprintf("filesystem on %v does not support d_type, "+
-			"see https://www.gravitational.com/docs/faq/#d_type-support-in-filesystem", string(r)),
+			"see https://www.gravitational.com/gravity/docs/faq/#d_type-support-in-filesystem", string(r)),
 		Status: pb.Probe_Failed,
 	})
 	return nil

--- a/monitoring/sysctl_checkers.go
+++ b/monitoring/sysctl_checkers.go
@@ -23,7 +23,7 @@ func NewIPForwardChecker() *SysctlChecker {
 		Param:           "net.ipv4.ip_forward",
 		Expected:        "1",
 		OnMissing:       "ipv4 forwarding status unknown",
-		OnValueMismatch: "ipv4 forwarding is off, see https://www.gravitational.com/docs/faq/#ipv4-forwarding",
+		OnValueMismatch: "ipv4 forwarding is off, see https://www.gravitational.com/gravity/docs/faq/#ipv4-forwarding",
 	}
 }
 
@@ -33,8 +33,8 @@ func NewBridgeNetfilterChecker() *SysctlChecker {
 		CheckerName:     NetfilterCheckerID,
 		Param:           "net.bridge.bridge-nf-call-iptables",
 		Expected:        "1",
-		OnMissing:       "br_netfilter module is either not loaded, or sysctl net.bridge.bridge-nf-call-iptables is not set, see https://www.gravitational.com/docs/faq/#bridge-driver",
-		OnValueMismatch: "kubernetes requires net.bridge.bridge-nf-call-iptables sysctl set to 1, https://www.gravitational.com/docs/faq/#bridge-driver",
+		OnMissing:       "br_netfilter module is either not loaded, or sysctl net.bridge.bridge-nf-call-iptables is not set, see https://www.gravitational.com/gravity/docs/faq/#bridge-driver",
+		OnValueMismatch: "kubernetes requires net.bridge.bridge-nf-call-iptables sysctl set to 1, https://www.gravitational.com/gravity/docs/faq/#bridge-driver",
 	}
 }
 
@@ -48,7 +48,7 @@ func NewMayDetachMountsChecker() *SysctlChecker {
 		CheckerName:     MountsCheckerID,
 		Param:           "fs.may_detach_mounts",
 		Expected:        "1",
-		OnValueMismatch: "fs.may_detach_mounts should be set to 1 or pods may get stuck in the Terminating state, see https://www.gravitational.com/docs/faq/#kubernetes-pods-stuck-in-terminating-state",
+		OnValueMismatch: "fs.may_detach_mounts should be set to 1 or pods may get stuck in the Terminating state, see https://www.gravitational.com/gravity/docs/faq/#kubernetes-pods-stuck-in-terminating-state",
 		SkipNotFound:    true, // It appears that this setting may not appear in non RHEL or older kernels, so don't fire the alert if we don't find the setting
 	}
 }
@@ -59,7 +59,7 @@ func NewCNIForwardingChecker() *SysctlChecker {
 		CheckerName:     CNIForwardChecker,
 		Param:           "net.ipv4.conf.cni0.forwarding",
 		Expected:        "1",
-		OnValueMismatch: "ipv4 forwarding is off on interface cni0, see https://www.gravitational.com/docs/faq/#ipv4-forwarding",
+		OnValueMismatch: "ipv4 forwarding is off on interface cni0, see https://www.gravitational.com/gravity/docs/faq/#ipv4-forwarding",
 		SkipNotFound:    true, // interface may not exist, so skip if not found
 	}
 }
@@ -70,7 +70,7 @@ func NewFlannelForwardingChecker() *SysctlChecker {
 		CheckerName:     FlannelForwardChecker,
 		Param:           "net.ipv4.conf.flannel/1.forwarding",
 		Expected:        "1",
-		OnValueMismatch: "ipv4 forwarding is off on interface flannel.1, see https://www.gravitational.com/docs/faq/#ipv4-forwarding",
+		OnValueMismatch: "ipv4 forwarding is off on interface flannel.1, see https://www.gravitational.com/gravity/docs/faq/#ipv4-forwarding",
 		SkipNotFound:    true, // interface may not exist, so skip if not found
 	}
 }
@@ -81,7 +81,7 @@ func NewWormholeBridgeForwardingChecker() *SysctlChecker {
 		CheckerName:     WormholeBridgeForwardChecker,
 		Param:           "net.ipv4.conf.wormhole-br0.forwarding",
 		Expected:        "1",
-		OnValueMismatch: "ipv4 forwarding is off on interface wormhole-br0, see https://www.gravitational.com/docs/faq/#ipv4-forwarding",
+		OnValueMismatch: "ipv4 forwarding is off on interface wormhole-br0, see https://www.gravitational.com/gravity/docs/faq/#ipv4-forwarding",
 		SkipNotFound:    true, // interface may not exist, so skip if not found
 	}
 }
@@ -92,7 +92,7 @@ func NewWormholeWgForwardingChecker() *SysctlChecker {
 		CheckerName:     WormholeWgForwardChecker,
 		Param:           "net.ipv4.conf.wormhole-wg0.forwarding",
 		Expected:        "1",
-		OnValueMismatch: "ipv4 forwarding is off on interface wormhole-wg0, see https://www.gravitational.com/docs/faq/#ipv4-forwarding",
+		OnValueMismatch: "ipv4 forwarding is off on interface wormhole-wg0, see https://www.gravitational.com/gravity/docs/faq/#ipv4-forwarding",
 		SkipNotFound:    true, // interface may not exist, so skip if not found
 	}
 }

--- a/monitoring/timedrift.go
+++ b/monitoring/timedrift.go
@@ -136,7 +136,8 @@ func (c *timeDriftChecker) check(ctx context.Context, r health.Reporter) (err er
 	for _, node := range nodes {
 		drift, err := c.getTimeDrift(ctx, node)
 		if err != nil {
-			return trace.Wrap(err)
+			log.WithError(err).Debug("Failed to get time drift.")
+			continue
 		}
 		if isDriftHigh(drift) {
 			r.Add(c.failureProbe(node, drift))


### PR DESCRIPTION
### Description
This PR slightly modifies the time drift check behavior. The time drift check can now report high time drift if there is an issue getting time drift from another node.

Changed a few logs from warning to debug level because they were flooding the logs.

Updated out of date docs links

### Linked tickets and PRs
* Ports https://github.com/gravitational/satellite/pull/242, https://github.com/gravitational/satellite/pull/243