### PR TITLE
[7.0.x] Kernel version check

### DIFF
--- a/monitoring/boot_config_linux_test.go
+++ b/monitoring/boot_config_linux_test.go
@@ -44,38 +44,6 @@ func (*MonitoringSuite) TestReadsBootConfig(c *C) {
 	})
 }
 
-func (*MonitoringSuite) TestParsesKernelVersion(c *C) {
-	// setup
-	var testCases = []struct {
-		release  string
-		expected KernelVersion
-		comment  string
-	}{
-		{
-			release:  "4.4.0-112-generic",
-			expected: KernelVersion{4, 4, 0},
-			comment:  "ubuntu 16.04",
-		},
-		{
-			release:  "3.10.0-514.16.1.el7.x86_64",
-			expected: KernelVersion{3, 10, 0},
-			comment:  "centos 7.4",
-		},
-		{
-			release:  "4.9.0-4-amd64",
-			expected: KernelVersion{4, 9, 0},
-			comment:  "debian 9.3",
-		},
-	}
-
-	// exercise / verify
-	for _, testCase := range testCases {
-		version, err := parseKernelVersion(testCase.release)
-		c.Assert(err, IsNil)
-		c.Assert(version, test.DeepCompare, &testCase.expected, Commentf(testCase.comment))
-	}
-}
-
 func (*MonitoringSuite) TestValidatesBootConfig(c *C) {
 	// setup
 	prober := newErrorProber(bootConfigParamID)
@@ -88,14 +56,14 @@ func (*MonitoringSuite) TestValidatesBootConfig(c *C) {
 	}{
 		{
 			params:              staticParams("CONFIG_PARAM2", "CONFIG_PARAM3"),
-			kernelVersionReader: staticKernelVersion("4.4.0"),
+			kernelVersionReader: staticKernelVersion("4.4.0-0"),
 			bootConfigReader:    testBootConfigReader(testBootConfig),
 			probes:              health.Probes{prober.newSuccess()},
 			comment:             "all parameters available",
 		},
 		{
 			params:              staticParams("CONFIG_PARAM1", "CONFIG_PARAM2"),
-			kernelVersionReader: staticKernelVersion("4.4.0"),
+			kernelVersionReader: staticKernelVersion("4.4.0-0"),
 			bootConfigReader:    testBootConfigReader(testBootConfig),
 			probes: health.Probes{
 				prober.newRaised("required kernel boot config parameter CONFIG_PARAM1 missing"),
@@ -108,7 +76,7 @@ func (*MonitoringSuite) TestValidatesBootConfig(c *C) {
 					Name:             "CONFIG_PARAM4",
 					KernelConstraint: KernelVersionLessThan(KernelVersion{Release: 4, Major: 4}),
 				}},
-			kernelVersionReader: staticKernelVersion("4.5.0"),
+			kernelVersionReader: staticKernelVersion("4.5.0-0"),
 			bootConfigReader:    testBootConfigReader(testBootConfig),
 			probes:              health.Probes{prober.newSuccess()},
 			comment:             "parameter should be skipped due to kernel version",
@@ -119,14 +87,14 @@ func (*MonitoringSuite) TestValidatesBootConfig(c *C) {
 					Name:             "CONFIG_PARAM4",
 					KernelConstraint: KernelVersionLessThan(KernelVersion{Release: 4, Major: 4}),
 				}},
-			kernelVersionReader: staticKernelVersion("4.5.0"),
+			kernelVersionReader: staticKernelVersion("4.5.0-0"),
 			bootConfigReader:    testBootConfigReader(testBootConfig),
 			probes:              health.Probes{prober.newSuccess()},
 			comment:             "parameter should be skipped due to kernel version",
 		},
 		{
 			params:              staticParams("CONFIG_PARAM"),
-			kernelVersionReader: staticKernelVersion("4.5.0"),
+			kernelVersionReader: staticKernelVersion("4.5.0-0"),
 			bootConfigReader:    testBootConfigFailingReader(trace.NotFound("file or directory not found")),
 			probes:              health.Probes{prober.newSuccess()},
 			comment:             "skip test if boot configuration is unavailable",
@@ -144,7 +112,7 @@ func (*MonitoringSuite) TestValidatesBootConfig(c *C) {
 		},
 		{
 			params:              staticParams("CONFIG_PARAM4", "CONFIG_PARAM5"),
-			kernelVersionReader: staticKernelVersion("4.5.0"),
+			kernelVersionReader: staticKernelVersion("4.5.0-0"),
 			bootConfigReader:    testBootConfigReader(testBootConfig),
 			probes: health.Probes{
 				prober.newRaised("required kernel boot config parameter CONFIG_PARAM4 missing"),

--- a/monitoring/defaults.go
+++ b/monitoring/defaults.go
@@ -77,3 +77,8 @@ func NewStorageChecker(config StorageConfig) (health.Checker, error) {
 func NewDNSChecker(questionA []string, nameservers ...string) health.Checker {
 	return noopChecker{}
 }
+
+// NewKernelChecker returns a new instance of kernel checker.
+func NewKernelChecker(version KernelVersion) health.Checker {
+	return noopChecker{}
+}

--- a/monitoring/kernel_checker_linux.go
+++ b/monitoring/kernel_checker_linux.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gravitational/satellite/agent/health"
+	pb "github.com/gravitational/satellite/agent/proto/agentpb"
+
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	kernelCheckerID = "kernel-check"
+)
+
+// kernelChecker is a checker that verifies that the linux kernel version is
+// supported by Gravity.
+type kernelChecker struct {
+	// MinKernelVersion specifies the minimum supported kernel version.
+	MinKernelVersion KernelVersion
+	// kernelVersionReader specifies the kernel version reader function.
+	kernelVersionReader
+}
+
+// NewKernelChecker returns a new instance of kernel checker.
+func NewKernelChecker(version KernelVersion) health.Checker {
+	return &kernelChecker{
+		MinKernelVersion:    version,
+		kernelVersionReader: realKernelVersionReader,
+	}
+}
+
+// Name returns the checker name.
+// Implements health.Checker.
+func (r *kernelChecker) Name() string {
+	return kernelCheckerID
+}
+
+// Check verifies kernel version.
+// Implements health.Checker.
+func (r *kernelChecker) Check(ctx context.Context, reporter health.Reporter) {
+	if err := r.check(ctx, reporter); err != nil {
+		log.WithError(err).Debug("Failed to verify kernel version.")
+		return
+	}
+}
+
+func (r *kernelChecker) check(_ context.Context, reporter health.Reporter) error {
+	release, err := r.kernelVersionReader()
+	if err != nil {
+		return trace.Wrap(err, "failed to read kernel version")
+	}
+
+	kernelVersion, err := parseKernelVersion(release)
+	if err != nil {
+		return trace.Wrap(err, "failed to determine kernel version: %s", release)
+	}
+
+	if !r.isSupportedVersion(*kernelVersion) {
+		reporter.Add(r.warningProbe(release))
+		return nil
+	}
+
+	reporter.Add(r.successProbe(release))
+	return nil
+}
+
+func (r *kernelChecker) successProbe(installedVersion string) *pb.Probe {
+	return &pb.Probe{
+		Checker: r.Name(),
+		Detail:  fmt.Sprintf("Installed Linux kernel is supported: %s.", installedVersion),
+		Status:  pb.Probe_Running,
+	}
+}
+
+func (r *kernelChecker) warningProbe(installedVersion string) *pb.Probe {
+	return &pb.Probe{
+		Checker: r.Name(),
+		Detail: fmt.Sprintf("Minimum recommended kernel version is %s (%s is installed).",
+			r.MinKernelVersion.String(), installedVersion),
+		Status:   pb.Probe_Failed,
+		Severity: pb.Probe_Warning,
+	}
+}
+
+// isSupportedVersion returns true if the provided linux kernel version is
+// supported by Gravity.
+func (r *kernelChecker) isSupportedVersion(version KernelVersion) bool {
+	return !KernelVersionLessThan(r.MinKernelVersion)(version)
+}

--- a/monitoring/kernel_checker_linux_test.go
+++ b/monitoring/kernel_checker_linux_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gravitational/satellite/agent/health"
+	pb "github.com/gravitational/satellite/agent/proto/agentpb"
+	"github.com/gravitational/satellite/lib/test"
+
+	. "gopkg.in/check.v1"
+)
+
+type KernelVersionSuite struct{}
+
+var _ = Suite(&KernelVersionSuite{})
+
+// TestKernelSupported verifies that the checker correctly identifies
+// supported/unsupported kernel versions.
+func (s *KernelVersionSuite) TestKernelSupported(c *C) {
+	var testCases = []struct {
+		comment CommentInterface
+		kernelVersionReader
+		probe *pb.Probe
+	}{
+		{
+			comment:             Commentf("RHEL 6.0"),
+			kernelVersionReader: staticKernelVersion("2.6.32-71"),
+			probe: &pb.Probe{
+				Checker: kernelCheckerID,
+				Detail: fmt.Sprintf("Minimum recommended kernel version is %s (%s is installed).",
+					testMinKernelVersion.String(), "2.6.32-71"),
+				Status:   pb.Probe_Failed,
+				Severity: pb.Probe_Warning,
+			},
+		},
+		{
+			comment:             Commentf("RHEL 7.6"),
+			kernelVersionReader: staticKernelVersion("3.10.0-957.12.2.el7.x86_64"),
+			probe: &pb.Probe{
+				Checker: kernelCheckerID,
+				Detail: fmt.Sprintf("Minimum recommended kernel version is %s (%s is installed).",
+					testMinKernelVersion.String(), "3.10.0-957.12.2.el7.x86_64"),
+				Status:   pb.Probe_Failed,
+				Severity: pb.Probe_Warning,
+			},
+		},
+		{
+			comment:             Commentf("RHEL 7.8"),
+			kernelVersionReader: staticKernelVersion("3.10.0-1127.13.1.el7.x86_64"),
+			probe: &pb.Probe{
+				Checker: kernelCheckerID,
+				Detail:  fmt.Sprintf("Installed Linux kernel is supported: %s.", "3.10.0-1127.13.1.el7.x86_64"),
+				Status:  pb.Probe_Running,
+			},
+		},
+		{
+			comment:             Commentf("Debian 9.3"),
+			kernelVersionReader: staticKernelVersion("4.9.0-4-amd64"),
+			probe: &pb.Probe{
+				Checker: kernelCheckerID,
+				Detail:  fmt.Sprintf("Installed Linux kernel is supported: %s.", "4.9.0-4-amd64"),
+				Status:  pb.Probe_Running,
+			},
+		},
+		{
+			comment:             Commentf("Ubuntu 19.10"),
+			kernelVersionReader: staticKernelVersion("5.3.0-62-generic"),
+			probe: &pb.Probe{
+				Checker: kernelCheckerID,
+				Detail:  fmt.Sprintf("Installed Linux kernel is supported: %s.", "5.3.0-62-generic"),
+				Status:  pb.Probe_Running,
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		checker := kernelChecker{
+			MinKernelVersion:    testMinKernelVersion,
+			kernelVersionReader: testCase.kernelVersionReader,
+		}
+		var reporter health.Probes
+		checker.Check(context.TODO(), &reporter)
+		c.Assert(reporter.GetProbes(), test.DeepCompare, []*pb.Probe{testCase.probe}, testCase.comment)
+	}
+}
+
+// testMinKernelVersion is the minimum supported kernel version used for test cases.
+var testMinKernelVersion = KernelVersion{Release: 3, Major: 10, Minor: 0, Patch: 1127}

--- a/monitoring/kernel_linux.go
+++ b/monitoring/kernel_linux.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/gravitational/trace"
+)
+
+// KernelVersion describes an abbreviated version of a Linux kernel.
+// It contains the kernel version (including major/minor components) and
+// patch number
+//
+// Example:
+//  $ uname -r
+//  $ 4.4.9-112-generic
+//
+// The result will be:
+//  KernelVersion{Release: 4, Major: 4, Minor: 9, Patch: 112}
+type KernelVersion struct {
+	// Release specifies the release of the kernel
+	Release int
+	// Major specifies the major version component
+	Major int
+	// Minor specifies the minor version component
+	Minor int
+	// Patch specifies the patch or build number
+	Patch int
+}
+
+// String returns the kernel version formatted as Release.Major.Minor-Patch.
+func (r *KernelVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d-%d", r.Release, r.Major, r.Minor, r.Patch)
+}
+
+// KernelConstraintFunc is a function to determine if the kernel version
+// satisfies a particular condition.
+type KernelConstraintFunc func(KernelVersion) bool
+
+// KernelVersionLessThan is a kernel constraint checker
+// that determines if the specified testVersion is less than
+// the actual version.
+func KernelVersionLessThan(version KernelVersion) KernelConstraintFunc {
+	return func(testVersion KernelVersion) bool {
+		if testVersion.Release != version.Release {
+			return testVersion.Release < version.Release
+		}
+
+		if testVersion.Major != version.Major {
+			return testVersion.Major < version.Major
+		}
+
+		if testVersion.Minor != version.Minor {
+			return testVersion.Minor < version.Minor
+		}
+
+		return testVersion.Patch < version.Patch
+	}
+}
+
+// kernelVersionReader returns the textual kernel version.
+type kernelVersionReader func() (version string, err error)
+
+// realKernelVersionReader reads and returns the currently installed Linux
+// kernel version.
+func realKernelVersionReader() (version string, err error) {
+	var uname syscall.Utsname
+	if err := syscall.Uname(&uname); err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return int8string(uname.Release[:]), nil
+}
+
+// parseKernelVersion parses the input string into a KernelVersion struct. The
+// input is expected to be a valid Linux kernel version in the format
+// Release.Major.Minor-Patch... trailing components will be ignored.
+//
+// Example:
+//  4.4.9-112-generic
+//
+// The result will be:
+//  KernelVersion{Release: 4, Major: 4, Minor: 9, Patch: 112}
+func parseKernelVersion(input string) (*KernelVersion, error) {
+	// componentsLength defines the expected number of kernel version components.
+	const componentsLength = 4
+
+	parts := strings.FieldsFunc(input, func(r rune) bool {
+		return r == '.' || r == '-'
+	})
+	if len(parts) < componentsLength {
+		return nil, trace.BadParameter("invalid kernel version input: %q", input)
+	}
+
+	version, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return nil, trace.BadParameter(
+			"invalid kernel version: %v, expected a number",
+			input)
+	}
+
+	major, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, trace.BadParameter(
+			"invalid kernel version major: %v, expected a number",
+			input)
+	}
+
+	minor, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return nil, trace.BadParameter(
+			"invalid kernel version minor: %v, expected a number",
+			input)
+	}
+
+	patch, err := strconv.Atoi(parts[3])
+	if err != nil {
+		return nil, trace.BadParameter(
+			"invalid kernel version patch: %v, expected a number",
+			input)
+	}
+
+	return &KernelVersion{
+		Release: version,
+		Major:   major,
+		Minor:   minor,
+		Patch:   patch,
+	}, nil
+}
+
+// int8string converts the bytes into a string.
+func int8string(bytes []int8) string {
+	result := make([]byte, 0, len(bytes))
+
+	for _, b := range bytes {
+		if b == 0 {
+			break
+		}
+
+		result = append(result, byte(b))
+	}
+
+	return string(result)
+}

--- a/monitoring/kernel_linux_test.go
+++ b/monitoring/kernel_linux_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"github.com/gravitational/satellite/lib/test"
+
+	. "gopkg.in/check.v1"
+)
+
+type KernelSuite struct{}
+
+var _ = Suite(&KernelSuite{})
+
+// TestParseKernelVersion verifies that the ParseKernelVersion correctly
+// parses the kernel version string into a KernelVersion struct.
+func (*KernelSuite) TestParsesKernelVersion(c *C) {
+	// setup
+	var testCases = []struct {
+		release  string
+		expected KernelVersion
+		comment  string
+	}{
+		{
+			release:  "4.4.0-112-generic",
+			expected: KernelVersion{4, 4, 0, 112},
+			comment:  "ubuntu 16.04",
+		},
+		{
+			release:  "3.10.0-514.16.1.el7.x86_64",
+			expected: KernelVersion{3, 10, 0, 514},
+			comment:  "centos 7.4",
+		},
+		{
+			release:  "4.9.0-4-amd64",
+			expected: KernelVersion{4, 9, 0, 4},
+			comment:  "debian 9.3",
+		},
+	}
+
+	// exercise / verify
+	for _, testCase := range testCases {
+		version, err := parseKernelVersion(testCase.release)
+		c.Assert(err, IsNil)
+		c.Assert(version, test.DeepCompare, &testCase.expected, Commentf(testCase.comment))
+	}
+}
+
+// TestKernelVersionLessThan verifies that KernelVersionLessThan correctly
+// compares the the specified kernel versions.
+func (*KernelSuite) TestKernelVersionLessThan(c *C) {
+	var testCases = []struct {
+		comment  CommentInterface
+		expected bool
+		version  KernelVersion
+	}{
+		{
+			comment:  Commentf("Exactly matches test version."),
+			expected: false,
+			version:  KernelVersion{Release: 3, Major: 10, Minor: 1, Patch: 1127},
+		},
+		{
+			comment:  Commentf("Older release version."),
+			expected: true,
+			version:  KernelVersion{Release: 2},
+		},
+		{
+			comment:  Commentf("Older release version & greater major component."),
+			expected: true,
+			version:  KernelVersion{Release: 2, Major: 11, Minor: 1, Patch: 1127},
+		},
+		{
+			comment:  Commentf("Older major component."),
+			expected: true,
+			version:  KernelVersion{Release: 3, Major: 9},
+		},
+		{
+			comment:  Commentf("Older minor component."),
+			expected: true,
+			version:  KernelVersion{Release: 3, Major: 10, Minor: 0},
+		},
+		{
+			comment:  Commentf("Older patch number."),
+			expected: true,
+			version:  KernelVersion{Release: 3, Major: 10, Minor: 1, Patch: 1126},
+		},
+		{
+			comment:  Commentf("Newer minor component."),
+			expected: false,
+			version:  KernelVersion{Release: 3, Major: 10, Minor: 2, Patch: 1126},
+		},
+		{
+			comment:  Commentf("Newer major component."),
+			expected: false,
+			version:  KernelVersion{Release: 3, Major: 11, Minor: 0, Patch: 1126},
+		},
+		{
+			comment:  Commentf("Newer release version."),
+			expected: false,
+			version:  KernelVersion{Release: 4, Major: 9, Minor: 0, Patch: 1126},
+		},
+	}
+
+	for _, testCase := range testCases {
+		result := KernelVersionLessThan(testKernelVersion)(testCase.version)
+		c.Assert(result, Equals, testCase.expected, testCase.comment)
+	}
+}
+
+// testKernelVersion is arbitrary kernel version used to test KernelVersionLessThan function.
+var testKernelVersion = KernelVersion{Release: 3, Major: 10, Minor: 1, Patch: 1127}


### PR DESCRIPTION
### Description
Add a kernel checker that checks if the currently installed kernel version is supported by Gravity.

### Linked tickets and PRs
Ports #248, #244