### PR TITLE
[5.5.x] serf client

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -551,12 +551,8 @@ func (r *agent) defaultUnknownStatus() *pb.NodeStatus {
 	return &pb.NodeStatus{
 		Name: r.Name,
 		MemberStatus: &pb.MemberStatus{
-			Name:   r.Name,
-			Addr:   r.RPCAddrs[0],
-			Status: pb.MemberStatus_None,
-			Tags:   r.Tags,
+			Name: r.Name,
 		},
-		Status: pb.NodeStatus_Unknown,
 	}
 }
 
@@ -774,18 +770,14 @@ func (r *agent) setLocalStatus(status *pb.NodeStatus) {
 	r.localStatus = status
 }
 
-// newSerfClient creates a new instance of the serf client and immediately
-// applies the the provided tags.
+// newSerfClient creates a new instance of the serf client.
 //
 // It is responsibility of the caller to close the returned client.
 func (r *agent) newSerfClient() (membership.ClusterMembership, error) {
 	client, err := membership.NewSerfClient(r.Config.SerfConfig)
 	if err != nil {
-		return nil, trace.Wrap(err, "failed to connect to serf agent: %v", r.Config.SerfConfig)
-	}
-	err = client.UpdateTags(r.Config.Tags, nil)
-	if err != nil {
-		return nil, trace.Wrap(err, "failed to update serf agent tags: %v", r.Config.Tags)
+		return nil, trace.Wrap(err, "failed to connect to serf agent: %#v",
+			r.Config.SerfConfig)
 	}
 	return client, nil
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -586,7 +586,7 @@ func (r *AgentSuite) newAgent(config testAgentConfig, client *mockClusterMembers
 		localStatus:             config.localStatus,
 		lastSeen:                lastSeen,
 		statusQueryReplyTimeout: statusQueryReplyTimeout,
-		newSerfClient:           newClusterMembershipFrom(client),
+		newSerfClientFunc:       newClusterMembershipFrom(client),
 	}
 
 	if err := r.becomeActiveMember(client, agent); err != nil {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -225,9 +225,9 @@ func (r *AgentSuite) TestAgentProvidesStatus(c *C) {
 	for _, testCase := range testCases {
 		agents := make([]*agent, 0, len(testCase.agentConfigs))
 		for _, agentConfig := range testCase.agentConfigs {
-			agent, err := r.newAgent(agentConfig)
+			agent, err := r.newAgent(agentConfig, testCase.membership)
 			c.Assert(err, IsNil, testCase.comment)
-			c.Assert(r.becomeMember(testCase.membership, agent, agentConfig.memberStatus), IsNil)
+			c.Assert(r.becomeMember(testCase.membership, agent, agentConfig.memberStatus), IsNil, testCase.comment)
 			agents = append(agents, agent)
 		}
 
@@ -275,17 +275,17 @@ func (r *AgentSuite) TestIsMember(c *C) {
 	for _, testCase := range testCases {
 		agents := make([]*agent, 0, len(testCase.agentConfigs))
 		for _, agentConfig := range testCase.agentConfigs {
-			agent, err := r.newAgent(agentConfig)
-			c.Assert(err, IsNil)
-			c.Assert(r.becomeActiveMember(testCase.membership, agent), IsNil)
+			agent, err := r.newAgent(agentConfig, testCase.membership)
+			c.Assert(err, IsNil, testCase.comment)
+			c.Assert(r.becomeActiveMember(testCase.membership, agent), IsNil, testCase.comment)
 			agents = append(agents, agent)
 		}
 
 		test.WithTimeout(func(ctx context.Context) {
 			for _, agent := range agents {
 				ok, err := agent.IsMember()
-				c.Assert(err, IsNil)
-				c.Assert(ok, Equals, testCase.expected)
+				c.Assert(err, IsNil, testCase.comment)
+				c.Assert(ok, Equals, testCase.expected, testCase.comment)
 			}
 		})
 	}
@@ -321,18 +321,17 @@ func (r *AgentSuite) TestRecordLocalTimeline(c *C) {
 		},
 	}
 
-	client := newMockClusterMembership()
 	for _, testCase := range testCases {
-		agent, err := r.newAgent(testCase.agentConfig)
-		c.Assert(err, IsNil)
-		c.Assert(r.becomeActiveMember(testCase.membership, agent), IsNil)
+		agent, err := r.newAgent(testCase.agentConfig, testCase.membership)
+		c.Assert(err, IsNil, testCase.comment)
+		c.Assert(r.becomeActiveMember(testCase.membership, agent), IsNil, testCase.comment)
 
 		test.WithTimeout(func(ctx context.Context) {
-			_, err := agent.collectLocalStatus(ctx, client)
-			c.Assert(err, IsNil)
+			_, err := agent.collectLocalStatus(ctx, testCase.membership)
+			c.Assert(err, IsNil, testCase.comment)
 
 			events, err := agent.LocalTimeline.GetEvents(ctx, nil)
-			c.Assert(err, IsNil)
+			c.Assert(err, IsNil, testCase.comment)
 			c.Assert(events, test.DeepCompare, testCase.expected, testCase.comment)
 		})
 	}
@@ -361,15 +360,15 @@ func (r *AgentSuite) TestRecordTimeline(c *C) {
 	}
 
 	for _, testCase := range testCases {
-		agent, err := r.newAgent(testCase.agentConfig)
-		c.Assert(err, IsNil)
-		c.Assert(r.becomeActiveMember(testCase.membership, agent), IsNil)
+		agent, err := r.newAgent(testCase.agentConfig, testCase.membership)
+		c.Assert(err, IsNil, testCase.comment)
+		c.Assert(r.becomeActiveMember(testCase.membership, agent), IsNil, testCase.comment)
 
 		test.WithTimeout(func(ctx context.Context) {
-			c.Assert(agent.RecordClusterEvents(ctx, testCase.events), IsNil)
+			c.Assert(agent.RecordClusterEvents(ctx, testCase.events), IsNil, testCase.comment)
 
 			events, err := agent.ClusterTimeline.GetEvents(ctx, nil)
-			c.Assert(err, IsNil)
+			c.Assert(err, IsNil, testCase.comment)
 			c.Assert(events, test.DeepCompare, testCase.expected, testCase.comment)
 		})
 	}
@@ -410,17 +409,18 @@ func (r *AgentSuite) TestAgentProvidesLastSeen(c *C) {
 		},
 	}
 
+	client := newMockClusterMembership()
 	for _, testCase := range testCases {
-		agent, err := r.newAgent(testCase.agentConfig)
-		c.Assert(err, IsNil)
+		agent, err := r.newAgent(testCase.agentConfig, client)
+		c.Assert(err, IsNil, testCase.comment)
 
 		test.WithTimeout(func(ctx context.Context) {
 			for _, timestamp := range testCase.timestamps {
-				c.Assert(agent.RecordLastSeen(agent.Name, timestamp), IsNil)
+				c.Assert(agent.RecordLastSeen(agent.Name, timestamp), IsNil, testCase.comment)
 			}
 
 			timestamp, err := agent.LastSeen(agent.Name)
-			c.Assert(err, IsNil)
+			c.Assert(err, IsNil, testCase.comment)
 			c.Assert(timestamp, test.DeepCompare, testCase.expected, testCase.comment)
 		})
 	}
@@ -496,34 +496,34 @@ func (r *AgentSuite) TestProvidesTimeline(c *C) {
 	for _, testCase := range testCases {
 		masters := make([]*agent, 0, len(testCase.masterConfigs))
 		for _, masterConfig := range testCase.masterConfigs {
-			master, err := r.newAgent(masterConfig)
-			c.Assert(err, IsNil)
-			c.Assert(r.becomeActiveMember(testCase.membership, master), IsNil)
+			master, err := r.newAgent(masterConfig, testCase.membership)
+			c.Assert(err, IsNil, testCase.comment)
+			c.Assert(r.becomeActiveMember(testCase.membership, master), IsNil, testCase.comment)
 			masters = append(masters, master)
 		}
 
 		nodes := make([]*agent, 0, len(testCase.nodeConfigs))
 		for _, nodeConfig := range testCase.nodeConfigs {
-			node, err := r.newAgent(nodeConfig)
-			c.Assert(err, IsNil)
-			c.Assert(r.becomeActiveMember(testCase.membership, node), IsNil)
+			node, err := r.newAgent(nodeConfig, testCase.membership)
+			c.Assert(err, IsNil, testCase.comment)
+			c.Assert(r.becomeActiveMember(testCase.membership, node), IsNil, testCase.comment)
 			nodes = append(nodes, node)
 		}
 
 		test.WithTimeout(func(ctx context.Context) {
 			for _, master := range masters {
 				_, err := master.collectLocalStatus(ctx, testCase.membership)
-				c.Assert(err, IsNil)
+				c.Assert(err, IsNil, testCase.comment)
 			}
 
 			for _, node := range nodes {
 				_, err := node.collectLocalStatus(ctx, testCase.membership)
-				c.Assert(err, IsNil)
+				c.Assert(err, IsNil, testCase.comment)
 			}
 
 			for _, master := range masters {
 				events, err := master.GetTimeline(ctx, nil)
-				c.Assert(err, IsNil)
+				c.Assert(err, IsNil, testCase.comment)
 				c.Assert(events, test.DeepCompare, testCase.expected, testCase.comment)
 			}
 		})
@@ -554,7 +554,7 @@ func (config *testAgentConfig) setDefaults() {
 }
 
 // newAgent creates a new agent instance.
-func (r *AgentSuite) newAgent(config testAgentConfig) (*agent, error) {
+func (r *AgentSuite) newAgent(config testAgentConfig, client *mockClusterMembership) (*agent, error) {
 	// timelineCapacity specifies the default timeline capacity for tests.
 	const timelineCapacity = 256
 	// clusterCapacity specifies the max number of nodes in a test cluster.
@@ -578,7 +578,6 @@ func (r *AgentSuite) newAgent(config testAgentConfig) (*agent, error) {
 		}
 	}
 
-	client := newMockClusterMembership()
 	agent := &agent{
 		ClusterTimeline:         memory.NewTimeline(config.clock, timelineCapacity),
 		LocalTimeline:           memory.NewTimeline(config.clock, timelineCapacity),
@@ -587,7 +586,7 @@ func (r *AgentSuite) newAgent(config testAgentConfig) (*agent, error) {
 		localStatus:             config.localStatus,
 		lastSeen:                lastSeen,
 		statusQueryReplyTimeout: statusQueryReplyTimeout,
-		newSerfClient:           newMockClusterMembershipCtor,
+		newSerfClient:           newClusterMembershipFrom(client),
 	}
 
 	if err := r.becomeActiveMember(client, agent); err != nil {
@@ -672,9 +671,10 @@ type mockClusterMembership struct {
 	members map[string]membership.ClusterMember
 }
 
-func newMockClusterMembershipCtor() (membership.ClusterMembership, error) {
-	client := newMockClusterMembership()
-	return client, nil
+func newClusterMembershipFrom(client *mockClusterMembership) func() (membership.ClusterMembership, error) {
+	return func() (membership.ClusterMembership, error) {
+		return client, nil
+	}
 }
 
 func newMockClusterMembership() *mockClusterMembership {
@@ -729,10 +729,6 @@ func (r *AgentSuite) becomeActiveMember(membership *mockClusterMembership, agent
 }
 
 func (r *AgentSuite) becomeMember(membership *mockClusterMembership, agent *agent, status MemberStatus) error {
-	if _, ok := membership.members[agent.Name]; ok {
-		return trace.BadParameter("member already added")
-	}
-
 	// Add agent to cluster membership.
 	membership.members[agent.Name] = newMockClusterMember(agent, status)
 

--- a/agent/proto/agentpb/suite_test.go
+++ b/agent/proto/agentpb/suite_test.go
@@ -25,10 +25,8 @@ import (
 )
 
 func init() {
-	if testing.Verbose() {
-		log.SetOutput(os.Stderr)
-		log.SetLevel(log.InfoLevel)
-	}
+	log.SetOutput(os.Stderr)
+	log.SetLevel(log.InfoLevel)
 }
 
 func TestSuite(t *testing.T) { TestingT(t) }

--- a/agent/server.go
+++ b/agent/server.go
@@ -353,7 +353,7 @@ type Agent interface {
 	// RecordLocalEvents records the events into the local timeline.
 	RecordLocalEvents(ctx context.Context, events []*pb.TimelineEvent) error
 	// IsMember returns whether this agent is already a member of serf cluster
-	IsMember() bool
+	IsMember() (ok bool, err error)
 	// GetConfig returns the agent configuration.
 	GetConfig() Config
 	// CheckerRepository allows to add checks to the agent.


### PR DESCRIPTION
This PR attempts to rectify the issue we were seeing on clusters with longer runtime and possibly suspended (hibernated) nodes (VMs). I'll create an issue to describe the specific behavior and problem.
Here, instead of using a single client instance per lifetime of the agent, the client is only created when necessary so the connections to serf are short-lived. This will help with:
  * serf RPC implicitly client closing a connection upon encountering a certain condition which we attempted to address previously by having client check for underlying client validity and reconnecting if invalid
  * serf client failing with `i/o timeout` when the connection to serf has run into a state when the remote side does not respond anymore (although TCP keep-alive packets are still going).
