### PR TITLE
(5.5) Update storage checker to support uid/gid checks

### DIFF
--- a/monitoring/storage.go
+++ b/monitoring/storage.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2018-2020 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -41,6 +41,10 @@ type StorageConfig struct {
 	// HighWatermark is the disk occupancy percentage that will trigger a critical probe.
 	// Disk usage check will be skipped if HighWatermark is unspecified or 0.
 	HighWatermark uint
+	// UID is the expected user owner of the path.
+	UID *uint32
+	// GID is the expected group owner of the path.
+	GID *uint32
 }
 
 // CheckAndSetDefaults validates this configuration object.
@@ -101,3 +105,49 @@ func (d HighWatermarkCheckerData) SuccessMessage() string {
 
 // DiskSpaceCheckerID is the checker that checks disk space utilization
 const DiskSpaceCheckerID = "disk-space"
+
+// PathUIDCheckerData is attached to path UID check results.
+type PathUIDCheckerData struct {
+	// ExpectedUID is the expected path UID.
+	ExpectedUID uint32 `json:"expected_uid"`
+	// ActualUID is the actual path UID.
+	ActualUID uint32 `json:"actual_uid"`
+	// Path is the path being checked.
+	Path string
+}
+
+// SuccessMessage returns success UID check message.
+func (d PathUIDCheckerData) SuccessMessage() string {
+	return fmt.Sprintf("path %s owner UID is %v", d.Path, d.ActualUID)
+}
+
+// FailureMessage return failure UID check message.
+func (d PathUIDCheckerData) FailureMessage() string {
+	return fmt.Sprintf("path %s owner UID is %v but is expected to be %v", d.Path, d.ActualUID, d.ExpectedUID)
+}
+
+// PathGIDCheckerData is attached to path GID check results.
+type PathGIDCheckerData struct {
+	// ExpectedGID is the expected path GID.
+	ExpectedGID uint32 `json:"expected_gid"`
+	// ActualGID is the actual path GID.
+	ActualGID uint32 `json:"actual_gid"`
+	// Path is the path being checked.
+	Path string
+}
+
+// SuccessMessage returns success GID check message.
+func (d PathGIDCheckerData) SuccessMessage() string {
+	return fmt.Sprintf("path %s owner GID is %v", d.Path, d.ActualGID)
+}
+
+// FailureMessage return failure GID check message.
+func (d PathGIDCheckerData) FailureMessage() string {
+	return fmt.Sprintf("path %s owner GID is %v but is expected to be %v", d.Path, d.ActualGID, d.ExpectedGID)
+}
+
+// PathUIDCheckerID is the checker that verifies path owner UID.
+const PathUIDCheckerID = "path-uid"
+
+// PathGIDCheckerID is the checker that verifies path owner GID.
+const PathGIDCheckerID = "path-gid"

--- a/monitoring/storage_linux.go
+++ b/monitoring/storage_linux.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Gravitational, Inc.
+Copyright 2017-2020 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/gravitational/satellite/agent/health"
@@ -34,7 +35,6 @@ import (
 	sigar "github.com/cloudfoundry/gosigar"
 	"github.com/dustin/go-humanize"
 	"github.com/gravitational/trace"
-	syscall "golang.org/x/sys/unix"
 )
 
 // NewStorageChecker creates a new instance of the volume checker
@@ -88,6 +88,7 @@ func (c *storageChecker) check(ctx context.Context, reporter health.Reporter) er
 
 	return trace.NewAggregate(c.checkFsType(ctx, reporter),
 		c.checkCapacity(ctx, reporter),
+		c.checkOwner(reporter),
 		c.checkDiskUsage(ctx, reporter),
 		c.checkWriteSpeed(ctx, reporter))
 }
@@ -144,6 +145,72 @@ func (c *storageChecker) checkFsType(ctx context.Context, reporter health.Report
 			c.Path, c.Filesystems, mnt.DirName, mnt.SysTypeName)
 	}
 	reporter.Add(probe)
+	return nil
+}
+
+// checkOwner verifies that the configured path is owned by the correct user/group.
+func (c *storageChecker) checkOwner(reporter health.Reporter) error {
+	if c.UID == nil && c.GID == nil {
+		return nil
+	}
+	uid, gid, err := c.osInterface.getUIDGID(c.Path)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if c.UID != nil {
+		data := PathUIDCheckerData{
+			Path:        c.Path,
+			ExpectedUID: *c.UID,
+			ActualUID:   uid,
+		}
+		bytes, err := json.Marshal(data)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if *c.UID != uid {
+			reporter.Add(&pb.Probe{
+				Checker:     PathUIDCheckerID,
+				CheckerData: bytes,
+				Status:      pb.Probe_Failed,
+				Severity:    pb.Probe_Warning,
+				Detail:      data.FailureMessage(),
+			})
+		} else {
+			reporter.Add(&pb.Probe{
+				Checker:     PathUIDCheckerID,
+				CheckerData: bytes,
+				Status:      pb.Probe_Running,
+				Detail:      data.SuccessMessage(),
+			})
+		}
+	}
+	if c.GID != nil {
+		data := PathGIDCheckerData{
+			Path:        c.Path,
+			ExpectedGID: *c.GID,
+			ActualGID:   gid,
+		}
+		bytes, err := json.Marshal(data)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if *c.GID != gid {
+			reporter.Add(&pb.Probe{
+				Checker:     PathGIDCheckerID,
+				CheckerData: bytes,
+				Status:      pb.Probe_Failed,
+				Severity:    pb.Probe_Warning,
+				Detail:      data.FailureMessage(),
+			})
+		} else {
+			reporter.Add(&pb.Probe{
+				Checker:     PathGIDCheckerID,
+				CheckerData: bytes,
+				Status:      pb.Probe_Running,
+				Detail:      data.SuccessMessage(),
+			})
+		}
+	}
 	return nil
 }
 
@@ -349,6 +416,22 @@ func (r realOS) diskCapacity(path string) (bytesAvail, bytesTotal uint64, err er
 	return bytesAvail, bytesTotal, nil
 }
 
+// getUIDGID returns the specified path's owner uid and gid.
+func (r realOS) getUIDGID(path string) (uid uint32, gid uint32, err error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0, 0, trace.Wrap(err)
+	}
+	if fi.Sys() == nil {
+		return 0, 0, trace.BadParameter("fileinfo is missing sysinfo: %v", fi)
+	}
+	stat, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, 0, trace.BadParameter("fileinfo unexpected sysinfo type: %[1]v %[1]T", fi.Sys())
+	}
+	return stat.Uid, stat.Gid, nil
+}
+
 func writeN(ctx context.Context, file *os.File, buf []byte, n int) error {
 	for i := 0; i < n; i++ {
 		_, err := file.Write(buf)
@@ -372,4 +455,5 @@ type osInterface interface {
 	mountInfo
 	diskSpeed(ctx context.Context, path, name string) (bps uint64, err error)
 	diskCapacity(path string) (bytesAvailable, bytesTotal uint64, err error)
+	getUIDGID(path string) (uid uint32, gid uint32, err error)
 }


### PR DESCRIPTION
This pull request updates the existing "storage" checker to also support verifying expected path ownership (uid/gid). This will be used by planet/gravity to verify proper state directory ownership. Refs https://github.com/gravitational/gravity/issues/2022.