### PR TITLE
increase nethealth rx queue

### DIFF
--- a/lib/nethealth/nethealth.go
+++ b/lib/nethealth/nethealth.go
@@ -59,6 +59,12 @@ const (
 
 	// DefaultServiceDiscoveryQuery is the default name to query for service discovery changes
 	DefaultServiceDiscoveryQuery = "any.nethealth"
+
+	// RxQueueSize is the size of queued ping responses to process
+	// Main processing occurs in a single goroutine, so we need a large enough processing queue to hold onto all ping
+	// responses while the routine is working on other operations.
+	// 2000 is chosen as double the maximum supported cluster size (1k)
+	RxQueueSize = 2000
 )
 
 const (
@@ -158,7 +164,7 @@ func (c Config) New() (*Server, error) {
 		promPeerRequest: promPeerRequest,
 		selector:        labelSelector,
 		triggerResync:   make(chan bool, 1),
-		rxMessage:       make(chan messageWrapper, 100),
+		rxMessage:       make(chan messageWrapper, RxQueueSize),
 		peers:           make(map[string]*peer),
 		addrToPeer:      make(map[string]string),
 	}, nil


### PR DESCRIPTION
Increase number of nethealth responses that can be queued for the cluster scalability work. There is likely more work to be done, but this change is needed to unblock the current known scaling limitation.