### PR TITLE
[master] scale tuning

### DIFF
--- a/cmd/nethealth/main.go
+++ b/cmd/nethealth/main.go
@@ -49,10 +49,12 @@ func run() error {
 		cversion = app.Command("version", "Display version")
 
 		// `run` command
-		crun               = app.Command("run", "Start nethealth agent")
-		crunPrometheusPort = crun.Flag("prom-port", "The prometheus port to bind to").Default("9801").Uint32()
-		crunNamespace      = crun.Flag("namespace", "The kubernetes namespace to watch for nethealth pods").
-					Default("monitoring").OverrideDefaultFromEnvar("POD_NAMESPACE").String()
+		crun                 = app.Command("run", "Start nethealth agent")
+		crunPrometheusPort   = crun.Flag("prom-port", "The prometheus port to bind to").Default("9801").Uint32()
+		crunPrometheusSocket = crun.Flag("prom-socket", "The unix-socket path to bind for prometheus metrics").
+					Default(nethealth.DefaultNethealthSocket).String()
+		crunNamespace = crun.Flag("namespace", "The kubernetes namespace to watch for nethealth pods").
+				Default("monitoring").OverrideDefaultFromEnvar("POD_NAMESPACE").String()
 		crunNodeName = crun.Flag("node-name", "The name of the node we're running on").
 				OverrideDefaultFromEnvar("NODE_NAME").String()
 		crunSelector = crun.Flag("pod-selector", "The kubernetes selector to identify nethealth pods").
@@ -85,10 +87,11 @@ func run() error {
 
 	case crun.FullCommand():
 		config := nethealth.Config{
-			PrometheusPort: *crunPrometheusPort,
-			Namespace:      *crunNamespace,
-			NodeName:       *crunNodeName,
-			Selector:       *crunSelector,
+			PrometheusPort:   *crunPrometheusPort,
+			PrometheusSocket: *crunPrometheusSocket,
+			Namespace:        *crunNamespace,
+			NodeName:         *crunNodeName,
+			Selector:         *crunSelector,
 		}
 
 		server, err := config.New()

--- a/lib/nethealth/nethealth.go
+++ b/lib/nethealth/nethealth.go
@@ -240,6 +240,16 @@ func (s *Server) Start() error {
 			s.Fatalf("ListenAndServe(): %s", err)
 		}
 	}()
+	go func() {
+		unixListener, err := net.Listen("unix", "/run/nethealth/nethealth.sock")
+		if err != nil {
+			panic(err)
+		}
+
+		if err := s.httpServer.Serve(unixListener); err != http.ErrServerClosed {
+			s.Fatalf("Unix Listen(): %s", err)
+		}
+	}()
 
 	s.Info("Started nethealth with config:")
 	s.Info("  PrometheusPort: ", s.config.PrometheusPort)

--- a/lib/nethealth/nethealth.go
+++ b/lib/nethealth/nethealth.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"reflect"
 	"sort"
 	"time"
@@ -65,6 +66,9 @@ const (
 	// responses while the routine is working on other operations.
 	// 2000 is chosen as double the maximum supported cluster size (1k)
 	RxQueueSize = 2000
+
+	// DefaultNethealthSocket is the default location of a unix domain socket that contains the prometheus metrics
+	DefaultNethealthSocket = "/run/nethealth/nethealth.sock"
 )
 
 const (
@@ -241,7 +245,9 @@ func (s *Server) Start() error {
 		}
 	}()
 	go func() {
-		unixListener, err := net.Listen("unix", "/run/nethealth/nethealth.sock")
+		_ = os.Remove(DefaultNethealthSocket)
+
+		unixListener, err := net.Listen("unix", DefaultNethealthSocket)
 		if err != nil {
 			panic(err)
 		}

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -355,11 +355,15 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 	}
 	defer resp.Body.Close()
 
+	log.Warn("nethealth got response: ", resp.Status)
+
 	if resp.StatusCode == http.StatusOK {
 		buffer, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return nil, trace.ConvertSystemError(err)
 		}
+
+		log.Warn("response: ", string(buffer))
 
 		return buffer, nil
 	}

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -325,23 +325,6 @@ func nethealthFailureProbe(name, peer string, packetLoss float64) *pb.Probe {
 // fetchNethealthMetrics collects the network metrics from the nethealth pod
 // specified by addr. Returns the resp as an array of bytes.
 func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byte, err error) {
-	/*if c.cachedNethealthAddress != "" {
-		c.cachedNethealthAddress, err = c.getNethealthAddr()
-		if trace.IsNotFound(err) {
-			log.Debug("Nethealth pod was not found.")
-			return nil, nil // pod was not found, log and treat gracefully
-		}
-
-		if err != nil {
-			return nil, trace.Wrap(err) // received unexpected error, maybe network-related, will add error probe above
-		}
-	}*/
-	/*
-		client, err := roundtrip.NewClient(c.cachedNethealthAddress, "")
-		if err != nil {
-			return nil, trace.Wrap(err, "failed to connect to nethealth service at %s.", c.cachedNethealthAddress)
-		}
-	*/
 	client := http.Client{
 		Transport: &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
@@ -361,7 +344,7 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 	//      # TYPE nethealth_echo_timeout_total counter
 	//      nethealth_echo_timeout_total{node_name="10.128.0.96",peer_name="10.128.0.70"} 37
 	//      nethealth_echo_timeout_total{node_name="10.128.0.96",peer_name="10.128.0.97"} 0
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "unix/metrics", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://unix/metrics", nil)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -46,8 +46,8 @@ import (
 type NethealthConfig struct {
 	// NodeName specifies the kubernetes name of this node.
 	NodeName string
-	// NethealthPort specifies the port that nethealth is listening on.
-	NethealthPort int
+	// NethealthSocketPath specifies the location of the unix-socket nethealth is listening on.
+	NethealthSocketPath string
 	// NetStatsInterval specifies the duration to store net stats.
 	NetStatsInterval time.Duration
 	// KubeConfig specifies kubernetes access information.
@@ -64,8 +64,8 @@ func (c *NethealthConfig) CheckAndSetDefaults() error {
 	if c.KubeConfig == nil {
 		errors = append(errors, trace.BadParameter("kubernetes access config must be provided"))
 	}
-	if c.NethealthPort == 0 {
-		c.NethealthPort = defaultNethealthPort
+	if c.NethealthSocketPath == "" {
+		c.NethealthSocketPath = nethealth.DefaultNethealthSocket
 	}
 	if c.NetStatsInterval == time.Duration(0) {
 		c.NetStatsInterval = defaultNetStatsInterval
@@ -294,13 +294,13 @@ func nethealthFailureProbe(name, peer string, packetLoss float64) *pb.Probe {
 	}
 }
 
-// fetchNethealthMetrics collects the network metrics from the nethealth pod
-// specified by addr. Returns the resp as an array of bytes.
+// fetchNethealthMetrics collects the network metrics from the nethealth pod.
+// Returns the resp as an array of bytes.
 func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byte, err error) {
 	client := http.Client{
 		Transport: &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", nethealth.DefaultNethealthSocket)
+				return net.Dial("unix", c.NethealthSocketPath)
 			},
 		},
 	}
@@ -336,7 +336,7 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 		return buffer, nil
 	}
 
-	return nil, trace.BadParameter("unexpected response from %s: %v", nethealth.DefaultNethealthSocket, resp.Status)
+	return nil, trace.BadParameter("unexpected response from %s: %v", c.NethealthSocketPath, resp.Status)
 }
 
 // parseMetrics parses the provided data and returns the structured network
@@ -501,9 +501,6 @@ const (
 	echoRequestLabel = "nethealth_echo_request_total"
 	// echoTimeoutLabel defines the metric family label for the echo timeout counter.
 	echoTimeoutLabel = "nethealth_echo_timeout_total"
-
-	// defaultNethealthPort defines the default nethealth port.
-	defaultNethealthPort = 9801
 
 	// defaultNetStatsInterval defines the default interval duration for the netStats.
 	defaultNetStatsInterval = 5 * time.Minute

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -355,15 +355,11 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 	}
 	defer resp.Body.Close()
 
-	log.Warn("nethealth got response: ", resp.Status)
-
 	if resp.StatusCode == http.StatusOK {
 		buffer, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return nil, trace.ConvertSystemError(err)
 		}
-
-		log.Warn("response: ", string(buffer))
 
 		return buffer, nil
 	}

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/satellite/agent"
 	"github.com/gravitational/satellite/agent/health"
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
+	"github.com/gravitational/satellite/lib/nethealth"
 	"github.com/gravitational/satellite/utils"
 
 	"github.com/gravitational/trace"
@@ -40,10 +41,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-)
-
-const (
-	DefaultNethealthSocket = "/run/nethealth/nethealth.sock"
 )
 
 // NethealthConfig specifies configuration for a nethealth checker.
@@ -345,11 +342,10 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 			return nil, trace.Wrap(err, "failed to connect to nethealth service at %s.", c.cachedNethealthAddress)
 		}
 	*/
-
 	client := http.Client{
 		Transport: &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", DefaultNethealthSocket)
+				return net.Dial("unix", nethealth.DefaultNethealthSocket)
 			},
 		},
 	}
@@ -385,7 +381,7 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 		return buffer, nil
 	}
 
-	return nil, trace.BadParameter("unexpected response from %s: %v", DefaultNethealthSocket, resp.Status)
+	return nil, trace.BadParameter("unexpected response from %s: %v", nethealth.DefaultNethealthSocket, resp.Status)
 }
 
 // parseMetrics parses the provided data and returns the structured network

--- a/monitoring/nethealth_test.go
+++ b/monitoring/nethealth_test.go
@@ -48,11 +48,11 @@ func (s *NethealthSuite) TestUpdateTimeoutStats(c *C) {
 				packetLoss: s.newPacketLoss(),
 			},
 			incomingData: []networkData{
-				networkData{},
-				networkData{},
-				networkData{},
-				networkData{},
-				networkData{},
+				{},
+				{},
+				{},
+				{},
+				{},
 			},
 		},
 		{
@@ -62,11 +62,11 @@ func (s *NethealthSuite) TestUpdateTimeoutStats(c *C) {
 				packetLoss:       s.newPacketLoss(),
 			},
 			incomingData: []networkData{
-				networkData{timeoutTotal: 1},
-				networkData{timeoutTotal: 2},
-				networkData{timeoutTotal: 3},
-				networkData{timeoutTotal: 4},
-				networkData{timeoutTotal: 5},
+				{timeoutTotal: 1},
+				{timeoutTotal: 2},
+				{timeoutTotal: 3},
+				{timeoutTotal: 4},
+				{timeoutTotal: 5},
 			},
 		},
 		{
@@ -76,11 +76,11 @@ func (s *NethealthSuite) TestUpdateTimeoutStats(c *C) {
 				packetLoss:       s.newPacketLoss(0, 0, 0, 0, 0),
 			},
 			incomingData: []networkData{
-				networkData{requestTotal: 1},
-				networkData{requestTotal: 2},
-				networkData{requestTotal: 3},
-				networkData{requestTotal: 4},
-				networkData{requestTotal: 5},
+				{requestTotal: 1},
+				{requestTotal: 2},
+				{requestTotal: 3},
+				{requestTotal: 4},
+				{requestTotal: 5},
 			},
 		},
 		{
@@ -91,11 +91,11 @@ func (s *NethealthSuite) TestUpdateTimeoutStats(c *C) {
 				packetLoss:       s.newPacketLoss(1, 1, 1, 1, 1),
 			},
 			incomingData: []networkData{
-				networkData{requestTotal: 1, timeoutTotal: 1},
-				networkData{requestTotal: 2, timeoutTotal: 2},
-				networkData{requestTotal: 3, timeoutTotal: 3},
-				networkData{requestTotal: 4, timeoutTotal: 4},
-				networkData{requestTotal: 5, timeoutTotal: 5},
+				{requestTotal: 1, timeoutTotal: 1},
+				{requestTotal: 2, timeoutTotal: 2},
+				{requestTotal: 3, timeoutTotal: 3},
+				{requestTotal: 4, timeoutTotal: 4},
+				{requestTotal: 5, timeoutTotal: 5},
 			},
 		},
 		{
@@ -106,12 +106,12 @@ func (s *NethealthSuite) TestUpdateTimeoutStats(c *C) {
 				packetLoss:       s.newPacketLoss(0, 0, 0, 0, 0),
 			},
 			incomingData: []networkData{
-				networkData{requestTotal: 1, timeoutTotal: 1},
-				networkData{requestTotal: 2, timeoutTotal: 1},
-				networkData{requestTotal: 3, timeoutTotal: 1},
-				networkData{requestTotal: 4, timeoutTotal: 1},
-				networkData{requestTotal: 5, timeoutTotal: 1},
-				networkData{requestTotal: 6, timeoutTotal: 1},
+				{requestTotal: 1, timeoutTotal: 1},
+				{requestTotal: 2, timeoutTotal: 1},
+				{requestTotal: 3, timeoutTotal: 1},
+				{requestTotal: 4, timeoutTotal: 1},
+				{requestTotal: 5, timeoutTotal: 1},
+				{requestTotal: 6, timeoutTotal: 1},
 			},
 		},
 	}
@@ -197,11 +197,11 @@ func (s *NethealthSuite) TestParseMetricsSuccess(c *C) {
 		{
 			comment: Commentf("Expected networkData for peers 10.128.0.70 and 10.128.0.97."),
 			expected: map[string]networkData{
-				"10.128.0.70": networkData{
+				"10.128.0.70": {
 					requestTotal: 236,
 					timeoutTotal: 37,
 				},
-				"10.128.0.97": networkData{
+				"10.128.0.97": {
 					requestTotal: 273,
 					timeoutTotal: 0,
 				},

--- a/monitoring/system_pods.go
+++ b/monitoring/system_pods.go
@@ -29,13 +29,10 @@ import (
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 )
 
 // SystemPodsConfig specifies configuration for a system pods checker.
 type SystemPodsConfig struct {
-	// NodeName specifies the kubernetes name of this node.
-	NodeName string
 	// KubeConfig specifies kubernetes access configuration.
 	*KubeConfig
 }
@@ -44,9 +41,6 @@ type SystemPodsConfig struct {
 // value defaults where necessary.
 func (r *SystemPodsConfig) checkAndSetDefaults() error {
 	var errors []error
-	if r.NodeName == "" {
-		errors = append(errors, trace.BadParameter("node name must be provided"))
-	}
 	if r.KubeConfig == nil {
 		errors = append(errors, trace.BadParameter("kubernetes access config must be provided"))
 	}
@@ -107,7 +101,6 @@ func (r *systemPodsChecker) check(ctx context.Context, reporter health.Reporter)
 func (r *systemPodsChecker) getPods() ([]corev1.Pod, error) {
 	opts := metav1.ListOptions{
 		LabelSelector: systemPodsSelector.String(),
-		FieldSelector: fields.OneTermEqualSelector("spec.nodeName", r.NodeName).String(),
 	}
 	pods, err := r.Client.CoreV1().Pods(kubernetes.AllNamespaces).List(opts)
 	if err != nil {

--- a/monitoring/system_pods_test.go
+++ b/monitoring/system_pods_test.go
@@ -32,9 +32,7 @@ type SystemPodsSuite struct {
 
 var _ = Suite(&SystemPodsSuite{
 	systemPodsChecker: systemPodsChecker{
-		SystemPodsConfig: SystemPodsConfig{
-			NodeName: "test-node",
-		},
+		SystemPodsConfig: SystemPodsConfig{},
 	},
 })
 

--- a/monitoring/timedrift.go
+++ b/monitoring/timedrift.go
@@ -210,8 +210,7 @@ func (c *timeDriftChecker) getTimeDrift(ctx context.Context, node serf.Member) (
 		return 0, trace.Wrap(err)
 	}
 
-	// Obtain this node's local timestamp.
-	t1Start := c.Clock.Now().UTC()
+	queryStart := c.Clock.Now().UTC()
 
 	// if the RPC call takes a long duration it will result in an inaccurate comparison. Timeout the RPC
 	// call to reduce false positives on a slow server.
@@ -219,7 +218,7 @@ func (c *timeDriftChecker) getTimeDrift(ctx context.Context, node serf.Member) (
 	defer cancel()
 
 	// Send "time" request to the specified node.
-	t2Response, err := agentClient.Time(ctx, &pb.TimeRequest{})
+	peerResponse, err := agentClient.Time(ctx, &pb.TimeRequest{})
 	if err != nil {
 		// If the agent we're making request to is of an older version,
 		// it may not support Time() method yet. This can happen, e.g.,
@@ -231,21 +230,21 @@ func (c *timeDriftChecker) getTimeDrift(ctx context.Context, node serf.Member) (
 		return 0, trace.Wrap(err)
 	}
 
-	// Calculate how much time has elapsed since T1Start. This value will
-	// roughly be the request roundtrip time, so the latency b/w the nodes
-	// is half that.
-	latency := c.Clock.Now().UTC().Sub(t1Start) / 2
+	queryEnd := c.Clock.Now().UTC()
 
-	// Finally calculate the time drift between this and the specified node
-	// using formula: t2 - now + latency.
-	//
-	// Example for 1ms difference: t2 = 0, now = 16ms, latency = 15 ms
-	// 0 - 16 = -16; -16 + 15 = -1 ms.
-	t2 := t2Response.GetTimestamp().ToTime()
-	drift := t2.Sub(c.Clock.Now().UTC()) + latency
+	// The request / response will take some time to perform over the network
+	// Use an adjustment of half the RTT time under the assumption that the request / response consume
+	// equal delays.
+	latencyAdjustment := queryEnd.Sub(queryStart) / 2
 
-	c.WithField("node", node.Name).Debugf("T1Start: %v; T2: %v; Latency: %v; Drift: %v.",
-		t1Start, t2, latency, drift)
+	adjustedPeerTime := peerResponse.GetTimestamp().ToTime().Add(latencyAdjustment)
+
+	// drift is relative to the current nodes time.
+	// if peer time > node time, return a positive duration
+	// if peer time < node time, return a negative duration
+	drift := adjustedPeerTime.Sub(queryEnd)
+	c.WithField("node", node.Name).Debugf("queryStart: %v; queryEnd: %v; peerTime: %v; latencyAdjust: %v drift: %v.",
+		queryStart, queryEnd, peerResponse.GetTimestamp().ToTime(), latencyAdjustment, drift)
 	return drift, nil
 }
 

--- a/monitoring/timedrift.go
+++ b/monitoring/timedrift.go
@@ -243,8 +243,8 @@ func (c *timeDriftChecker) getTimeDrift(ctx context.Context, node serf.Member) (
 	// if peer time > node time, return a positive duration
 	// if peer time < node time, return a negative duration
 	drift := adjustedPeerTime.Sub(queryEnd)
-	c.WithField("node", node.Name).Debugf("queryStart: %v; queryEnd: %v; peerTime: %v; latencyAdjust: %v drift: %v.",
-		queryStart, queryEnd, peerResponse.GetTimestamp().ToTime(), latencyAdjustment, drift)
+	c.WithField("node", node.Name).Debugf("queryStart: %v; queryEnd: %v; peerTime: %v; adjustedPeerTime: %v drift: %v.",
+		queryStart, queryEnd, peerResponse.GetTimestamp().ToTime(), adjustedPeerTime, drift)
 	return drift, nil
 }
 


### PR DESCRIPTION
1. Instead of locating the nethealth pod by querying the kubernetes cluster, nethealth will instead listen to a unix domain socket that will be mapped to planet. Satellite queries the metrics via unix domain socket.
    Note: I left the prometheus endpoint, just incase there is a use case still for querying over the network
2. Do a bit of cleanup on the timedrift calculations. Makes it a bit easier for me atleast to understand the algorithm, of which I think I reversed the +/- a few times on the adjustment factor for the query latency.
3. Have system pod checkers run only on master nodes (this is changed within planet). This way, 800 workers aren't all trying to query kubernetes to check just themselves.