### PR TITLE
[7.0.x] fix http context

### DIFF
--- a/agent/proto/agentpb/suite_test.go
+++ b/agent/proto/agentpb/suite_test.go
@@ -24,14 +24,14 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func init() {
+func TestSuite(t *testing.T) {
 	if testing.Verbose() {
 		log.SetOutput(os.Stderr)
 		log.SetLevel(log.InfoLevel)
 	}
-}
 
-func TestSuite(t *testing.T) { TestingT(t) }
+	TestingT(t)
+}
 
 type ProtoSuite struct{}
 

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -303,7 +303,6 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 				return net.Dial("unix", c.NethealthSocketPath)
 			},
 		},
-		Timeout: time.Second,
 	}
 	// The two relevant metrics exposed by nethealth are 'nethealth_echo_request_total' and
 	// 'nethealth_echo_timeout_total'. We expect a pair of request/timeout metrics per peer.
@@ -321,6 +320,8 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	req = req.WithContext(ctx)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -303,6 +303,7 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 				return net.Dial("unix", c.NethealthSocketPath)
 			},
 		},
+		Timeout: time.Second,
 	}
 	// The two relevant metrics exposed by nethealth are 'nethealth_echo_request_total' and
 	// 'nethealth_echo_timeout_total'. We expect a pair of request/timeout metrics per peer.
@@ -316,7 +317,7 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 	//      # TYPE nethealth_echo_timeout_total counter
 	//      nethealth_echo_timeout_total{node_name="10.128.0.96",peer_name="10.128.0.70"} 37
 	//      nethealth_echo_timeout_total{node_name="10.128.0.96",peer_name="10.128.0.97"} 0
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://unix/metrics", nil)
+	req, err := http.NewRequest(http.MethodGet, "http://unix/metrics", nil)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -300,9 +300,11 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 	client := http.Client{
 		Transport: &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", c.NethealthSocketPath)
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", c.NethealthSocketPath)
 			},
 		},
+		Timeout: time.Second,
 	}
 	// The two relevant metrics exposed by nethealth are 'nethealth_echo_request_total' and
 	// 'nethealth_echo_timeout_total'. We expect a pair of request/timeout metrics per peer.


### PR DESCRIPTION
- This fixes an issue on backport, where we're using a version of golang that doesn't have http.NewRequestWithContext
- Also fixes an issue I noticed in the tests, where the tests panic if `testing.Verbose` is called within `init()`. I just dropped the logging config within the test suite for now, there might be a better way to address this long term.