### PR TITLE
scaling: timedrift false positives at scale (#265)

### DIFF
--- a/monitoring/timedrift.go
+++ b/monitoring/timedrift.go
@@ -40,6 +40,14 @@ const (
 	// timeDriftThreshold sets the default threshold of the acceptable time
 	// difference between nodes.
 	timeDriftThreshold = 300 * time.Millisecond
+
+	// timeDriftCheckTimeout drops time checks where the RPC call to the remote server take too long to respond.
+	// If the client or server is busy and the request takes too long to be processed, this will cause an inaccurate
+	// comparison of the current time.
+	timeDriftCheckTimeout = 100 * time.Millisecond
+
+	// parallelRoutines indicates how many parallel queries we should run to peer nodes
+	parallelRoutines = 20
 )
 
 // timeDriftChecker is a checker that verifies that the time difference between
@@ -133,16 +141,39 @@ func (c *timeDriftChecker) check(ctx context.Context, r health.Reporter) (err er
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	nodesC := make(chan serf.Member, len(nodes))
 	for _, node := range nodes {
-		drift, err := c.getTimeDrift(ctx, node)
-		if err != nil {
-			log.WithError(err).Debug("Failed to get time drift.")
-			continue
-		}
-		if isDriftHigh(drift) {
-			r.Add(c.failureProbe(node, drift))
-		}
+		nodesC <- node
 	}
+	close(nodesC)
+
+	var mutex sync.Mutex
+
+	var wg sync.WaitGroup
+
+	wg.Add(parallelRoutines)
+
+	for i := 0; i < parallelRoutines; i++ {
+		go func() {
+			for node := range nodesC {
+				drift, err := c.getTimeDrift(ctx, node)
+				if err != nil {
+					log.WithError(err).Debug("Failed to get time drift.")
+					continue
+				}
+
+				if isDriftHigh(drift) {
+					mutex.Lock()
+					r.Add(c.failureProbe(node, drift))
+					mutex.Unlock()
+				}
+			}
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
 	return nil
 }
 
@@ -180,6 +211,11 @@ func (c *timeDriftChecker) getTimeDrift(ctx context.Context, node serf.Member) (
 	}
 
 	queryStart := c.Clock.Now().UTC()
+
+	// if the RPC call takes a long duration it will result in an inaccurate comparison. Timeout the RPC
+	// call to reduce false positives on a slow server.
+	ctx, cancel := context.WithTimeout(ctx, timeDriftCheckTimeout)
+	defer cancel()
 
 	// Send "time" request to the specified node.
 	peerResponse, err := agentClient.Time(ctx, &pb.TimeRequest{})

--- a/monitoring/timedrift_test.go
+++ b/monitoring/timedrift_test.go
@@ -57,6 +57,8 @@ func (s *TimeDriftSuite) TestTimeDriftChecker(c *check.C) {
 		times map[string]time.Time
 		// result is the time drift check result.
 		result []*agentpb.Probe
+		// slow indicates the server should respond slowly
+		slow bool
 	}{
 		{
 			comment: "Acceptable time drift",
@@ -116,6 +118,18 @@ func (s *TimeDriftSuite) TestTimeDriftChecker(c *check.C) {
 				s.c.failureProbe(node3, driftOverThreshold()),
 			},
 		},
+		{
+			comment: "Time drift takes too long to respond silently discarding results",
+			slow:    true,
+			nodes:   []serf.Member{node1, node2, node3},
+			times: map[string]time.Time{
+				node2.Name: s.clock.Now().Add(-driftOverThreshold()),
+				node3.Name: s.clock.Now().Add(driftOverThreshold()),
+			},
+			result: []*agentpb.Probe{
+				s.c.successProbe(),
+			},
+		},
 	}
 	for _, test := range tests {
 		checker := &timeDriftChecker{
@@ -128,7 +142,14 @@ func (s *TimeDriftSuite) TestTimeDriftChecker(c *check.C) {
 			clients:     newClientsCache(test.times),
 		}
 		var probes health.Probes
-		checker.Check(context.TODO(), &probes)
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		if test.slow {
+			cancel()
+		}
+
+		checker.Check(ctx, &probes)
 		c.Assert(probes.GetProbes(), check.DeepEquals, test.result,
 			check.Commentf(test.comment))
 	}
@@ -166,6 +187,11 @@ func (a *mockedTimeAgentClient) LastSeen(ctx context.Context,
 }
 
 func (a *mockedTimeAgentClient) Time(ctx context.Context, req *agentpb.TimeRequest) (*agentpb.TimeResponse, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
 	return &agentpb.TimeResponse{
 		Timestamp: agentpb.NewTimeToProto(a.time),
 	}, nil


### PR DESCRIPTION
* scaling: parallel timedrift calls to peers; discard timedrift results from slow RPC calls

* address review comments; fix error in formula

* address review feedback

* address review feedback

(cherry picked from commit ed6bca08a4852ac095d24037359ad7aef4c27e8e)