### PR TITLE
[6.1] g1k backport

### DIFF
--- a/agent/proto/agentpb/suite_test.go
+++ b/agent/proto/agentpb/suite_test.go
@@ -24,14 +24,14 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func init() {
+func TestSuite(t *testing.T) {
 	if testing.Verbose() {
 		log.SetOutput(os.Stderr)
 		log.SetLevel(log.InfoLevel)
 	}
-}
 
-func TestSuite(t *testing.T) { TestingT(t) }
+	TestingT(t)
+}
 
 type ProtoSuite struct{}
 

--- a/cmd/nethealth/main.go
+++ b/cmd/nethealth/main.go
@@ -49,10 +49,12 @@ func run() error {
 		cversion = app.Command("version", "Display version")
 
 		// `run` command
-		crun               = app.Command("run", "Start nethealth agent")
-		crunPrometheusPort = crun.Flag("prom-port", "The prometheus port to bind to").Default("9801").Uint32()
-		crunNamespace      = crun.Flag("namespace", "The kubernetes namespace to watch for nethealth pods").
-					Default("monitoring").OverrideDefaultFromEnvar("POD_NAMESPACE").String()
+		crun                 = app.Command("run", "Start nethealth agent")
+		crunPrometheusPort   = crun.Flag("prom-port", "The prometheus port to bind to").Default("9801").Uint32()
+		crunPrometheusSocket = crun.Flag("prom-socket", "The unix-socket path to bind for prometheus metrics").
+					Default(nethealth.DefaultNethealthSocket).String()
+		crunNamespace = crun.Flag("namespace", "The kubernetes namespace to watch for nethealth pods").
+				Default("monitoring").OverrideDefaultFromEnvar("POD_NAMESPACE").String()
 		crunNodeName = crun.Flag("node-name", "The name of the node we're running on").
 				OverrideDefaultFromEnvar("NODE_NAME").String()
 		crunSelector = crun.Flag("pod-selector", "The kubernetes selector to identify nethealth pods").
@@ -82,10 +84,11 @@ func run() error {
 
 	case crun.FullCommand():
 		config := nethealth.Config{
-			PrometheusPort: *crunPrometheusPort,
-			Namespace:      *crunNamespace,
-			NodeName:       *crunNodeName,
-			Selector:       *crunSelector,
+			PrometheusPort:   *crunPrometheusPort,
+			PrometheusSocket: *crunPrometheusSocket,
+			Namespace:        *crunNamespace,
+			NodeName:         *crunNodeName,
+			Selector:         *crunSelector,
 		}
 
 		server, err := config.New()

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -20,22 +20,24 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/ioutil"
 	"math"
+	"net"
+	"net/http"
 	"sync"
 	"time"
 
 	"github.com/gravitational/satellite/agent"
 	"github.com/gravitational/satellite/agent/health"
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
+	"github.com/gravitational/satellite/lib/nethealth"
 	"github.com/gravitational/satellite/utils"
 
-	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
 	"github.com/mailgun/holster"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	log "github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 )
@@ -44,8 +46,8 @@ import (
 type NethealthConfig struct {
 	// NodeName specifies the kubernetes name of this node.
 	NodeName string
-	// NethealthPort specifies the port that nethealth is listening on.
-	NethealthPort int
+	// NethealthSocketPath specifies the location of the unix-socket nethealth is listening on.
+	NethealthSocketPath string
 	// NetStatsInterval specifies the duration to store net stats.
 	NetStatsInterval time.Duration
 	// KubeConfig specifies kubernetes access information.
@@ -62,8 +64,8 @@ func (c *NethealthConfig) CheckAndSetDefaults() error {
 	if c.KubeConfig == nil {
 		errors = append(errors, trace.BadParameter("kubernetes access config must be provided"))
 	}
-	if c.NethealthPort == 0 {
-		c.NethealthPort = defaultNethealthPort
+	if c.NethealthSocketPath == "" {
+		c.NethealthSocketPath = nethealth.DefaultNethealthSocket
 	}
 	if c.NetStatsInterval == time.Duration(0) {
 		c.NetStatsInterval = defaultNetStatsInterval
@@ -127,16 +129,7 @@ func (c *nethealthChecker) check(ctx context.Context, reporter health.Reporter) 
 		return nil
 	}
 
-	addr, err := c.getNethealthAddr()
-	if trace.IsNotFound(err) {
-		log.Debug("Nethealth pod was not found.")
-		return nil // pod was not found, log and treat gracefully
-	}
-	if err != nil {
-		return trace.Wrap(err) // received unexpected error, maybe network-related, will add error probe above
-	}
-
-	resp, err := fetchNethealthMetrics(ctx, addr)
+	resp, err := c.fetchNethealthMetrics(ctx)
 	if err != nil {
 		return trace.Wrap(err, "failed to fetch nethealth metrics")
 	}
@@ -171,33 +164,6 @@ func (c *nethealthChecker) getPeers() (peers []string, err error) {
 		peers = append(peers, pod.Spec.NodeName)
 	}
 	return peers, nil
-}
-
-// getNethealthAddr returns the address of the local nethealth pod.
-func (c *nethealthChecker) getNethealthAddr() (addr string, err error) {
-	opts := metav1.ListOptions{
-		LabelSelector: nethealthLabelSelector.String(),
-		FieldSelector: fields.OneTermEqualSelector("spec.nodeName", c.NodeName).String(),
-		Limit:         1,
-	}
-	pods, err := c.Client.CoreV1().Pods(nethealthNamespace).List(opts)
-	if err != nil {
-		return addr, utils.ConvertError(err) // this will convert error to a proper trace error, e.g. trace.NotFound
-	}
-
-	if len(pods.Items) < 1 {
-		return addr, trace.NotFound("nethealth pod not found on local node %s", c.NodeName)
-	}
-
-	pod := pods.Items[0]
-	if pod.Status.Phase != corev1.PodRunning {
-		return addr, trace.NotFound("local nethealth pod %v is not Running: %v", pod.Name, pod.Status.Phase)
-	}
-	if pod.Status.PodIP == "" {
-		return addr, trace.NotFound("local nethealth pod %v has not been assigned an IP", pod.Name)
-	}
-
-	return fmt.Sprintf("http://%s:%d", pod.Status.PodIP, c.NethealthPort), nil
 }
 
 // updateStats updates netStats with new incoming data.
@@ -328,14 +294,16 @@ func nethealthFailureProbe(name, peer string, packetLoss float64) *pb.Probe {
 	}
 }
 
-// fetchNethealthMetrics collects the network metrics from the nethealth pod
-// specified by addr. Returns the resp as an array of bytes.
-func fetchNethealthMetrics(ctx context.Context, addr string) ([]byte, error) {
-	client, err := roundtrip.NewClient(addr, "")
-	if err != nil {
-		return nil, trace.Wrap(err, "failed to connect to nethealth service at %s.", addr)
+// fetchNethealthMetrics collects the network metrics from the nethealth pod.
+// Returns the response as an array of bytes.
+func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byte, err error) {
+	client := http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", c.NethealthSocketPath)
+			},
+		},
 	}
-
 	// The two relevant metrics exposed by nethealth are 'nethealth_echo_request_total' and
 	// 'nethealth_echo_timeout_total'. We expect a pair of request/timeout metrics per peer.
 	// Example metrics received from nethealth may look something like the output below:
@@ -348,11 +316,27 @@ func fetchNethealthMetrics(ctx context.Context, addr string) ([]byte, error) {
 	//      # TYPE nethealth_echo_timeout_total counter
 	//      nethealth_echo_timeout_total{node_name="10.128.0.96",peer_name="10.128.0.70"} 37
 	//      nethealth_echo_timeout_total{node_name="10.128.0.96",peer_name="10.128.0.97"} 0
-	resp, err := client.Get(ctx, client.Endpoint("metrics"), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://unix/metrics", nil)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return resp.Bytes(), nil
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		buffer, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, trace.ConvertSystemError(err)
+		}
+
+		return buffer, nil
+	}
+
+	return nil, trace.BadParameter("unexpected response from %s: %v", c.NethealthSocketPath, resp.Status)
 }
 
 // parseMetrics parses the provided data and returns the structured network
@@ -517,9 +501,6 @@ const (
 	echoRequestLabel = "nethealth_echo_request_total"
 	// echoTimeoutLabel defines the metric family label for the echo timeout counter.
 	echoTimeoutLabel = "nethealth_echo_timeout_total"
-
-	// defaultNethealthPort defines the default nethealth port.
-	defaultNethealthPort = 9801
 
 	// defaultNetStatsInterval defines the default interval duration for the netStats.
 	defaultNetStatsInterval = 5 * time.Minute

--- a/monitoring/nethealth_test.go
+++ b/monitoring/nethealth_test.go
@@ -48,11 +48,11 @@ func (s *NethealthSuite) TestUpdateTimeoutStats(c *C) {
 				packetLoss: s.newPacketLoss(),
 			},
 			incomingData: []networkData{
-				networkData{},
-				networkData{},
-				networkData{},
-				networkData{},
-				networkData{},
+				{},
+				{},
+				{},
+				{},
+				{},
 			},
 		},
 		{
@@ -62,11 +62,11 @@ func (s *NethealthSuite) TestUpdateTimeoutStats(c *C) {
 				packetLoss:       s.newPacketLoss(),
 			},
 			incomingData: []networkData{
-				networkData{timeoutTotal: 1},
-				networkData{timeoutTotal: 2},
-				networkData{timeoutTotal: 3},
-				networkData{timeoutTotal: 4},
-				networkData{timeoutTotal: 5},
+				{timeoutTotal: 1},
+				{timeoutTotal: 2},
+				{timeoutTotal: 3},
+				{timeoutTotal: 4},
+				{timeoutTotal: 5},
 			},
 		},
 		{
@@ -76,11 +76,11 @@ func (s *NethealthSuite) TestUpdateTimeoutStats(c *C) {
 				packetLoss:       s.newPacketLoss(0, 0, 0, 0, 0),
 			},
 			incomingData: []networkData{
-				networkData{requestTotal: 1},
-				networkData{requestTotal: 2},
-				networkData{requestTotal: 3},
-				networkData{requestTotal: 4},
-				networkData{requestTotal: 5},
+				{requestTotal: 1},
+				{requestTotal: 2},
+				{requestTotal: 3},
+				{requestTotal: 4},
+				{requestTotal: 5},
 			},
 		},
 		{
@@ -91,11 +91,11 @@ func (s *NethealthSuite) TestUpdateTimeoutStats(c *C) {
 				packetLoss:       s.newPacketLoss(1, 1, 1, 1, 1),
 			},
 			incomingData: []networkData{
-				networkData{requestTotal: 1, timeoutTotal: 1},
-				networkData{requestTotal: 2, timeoutTotal: 2},
-				networkData{requestTotal: 3, timeoutTotal: 3},
-				networkData{requestTotal: 4, timeoutTotal: 4},
-				networkData{requestTotal: 5, timeoutTotal: 5},
+				{requestTotal: 1, timeoutTotal: 1},
+				{requestTotal: 2, timeoutTotal: 2},
+				{requestTotal: 3, timeoutTotal: 3},
+				{requestTotal: 4, timeoutTotal: 4},
+				{requestTotal: 5, timeoutTotal: 5},
 			},
 		},
 		{
@@ -106,12 +106,12 @@ func (s *NethealthSuite) TestUpdateTimeoutStats(c *C) {
 				packetLoss:       s.newPacketLoss(0, 0, 0, 0, 0),
 			},
 			incomingData: []networkData{
-				networkData{requestTotal: 1, timeoutTotal: 1},
-				networkData{requestTotal: 2, timeoutTotal: 1},
-				networkData{requestTotal: 3, timeoutTotal: 1},
-				networkData{requestTotal: 4, timeoutTotal: 1},
-				networkData{requestTotal: 5, timeoutTotal: 1},
-				networkData{requestTotal: 6, timeoutTotal: 1},
+				{requestTotal: 1, timeoutTotal: 1},
+				{requestTotal: 2, timeoutTotal: 1},
+				{requestTotal: 3, timeoutTotal: 1},
+				{requestTotal: 4, timeoutTotal: 1},
+				{requestTotal: 5, timeoutTotal: 1},
+				{requestTotal: 6, timeoutTotal: 1},
 			},
 		},
 	}
@@ -197,11 +197,11 @@ func (s *NethealthSuite) TestParseMetricsSuccess(c *C) {
 		{
 			comment: Commentf("Expected networkData for peers 10.128.0.70 and 10.128.0.97."),
 			expected: map[string]networkData{
-				"10.128.0.70": networkData{
+				"10.128.0.70": {
 					requestTotal: 236,
 					timeoutTotal: 37,
 				},
-				"10.128.0.97": networkData{
+				"10.128.0.97": {
 					requestTotal: 273,
 					timeoutTotal: 0,
 				},

--- a/monitoring/system_pods.go
+++ b/monitoring/system_pods.go
@@ -29,13 +29,10 @@ import (
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 )
 
 // SystemPodsConfig specifies configuration for a system pods checker.
 type SystemPodsConfig struct {
-	// NodeName specifies the kubernetes name of this node.
-	NodeName string
 	// KubeConfig specifies kubernetes access configuration.
 	*KubeConfig
 }
@@ -44,9 +41,6 @@ type SystemPodsConfig struct {
 // value defaults where necessary.
 func (r *SystemPodsConfig) checkAndSetDefaults() error {
 	var errors []error
-	if r.NodeName == "" {
-		errors = append(errors, trace.BadParameter("node name must be provided"))
-	}
 	if r.KubeConfig == nil {
 		errors = append(errors, trace.BadParameter("kubernetes access config must be provided"))
 	}
@@ -107,7 +101,6 @@ func (r *systemPodsChecker) check(ctx context.Context, reporter health.Reporter)
 func (r *systemPodsChecker) getPods() ([]corev1.Pod, error) {
 	opts := metav1.ListOptions{
 		LabelSelector: systemPodsSelector.String(),
-		FieldSelector: fields.OneTermEqualSelector("spec.nodeName", r.NodeName).String(),
 	}
 	pods, err := r.Client.CoreV1().Pods(kubernetes.AllNamespaces).List(opts)
 	if err != nil {

--- a/monitoring/system_pods_test.go
+++ b/monitoring/system_pods_test.go
@@ -32,9 +32,7 @@ type SystemPodsSuite struct {
 
 var _ = Suite(&SystemPodsSuite{
 	systemPodsChecker: systemPodsChecker{
-		SystemPodsConfig: SystemPodsConfig{
-			NodeName: "test-node",
-		},
+		SystemPodsConfig: SystemPodsConfig{},
 	},
 })
 

--- a/monitoring/timedrift.go
+++ b/monitoring/timedrift.go
@@ -40,6 +40,14 @@ const (
 	// timeDriftThreshold sets the default threshold of the acceptable time
 	// difference between nodes.
 	timeDriftThreshold = 300 * time.Millisecond
+
+	// timeDriftCheckTimeout drops time checks where the RPC call to the remote server take too long to respond.
+	// If the client or server is busy and the request takes too long to be processed, this will cause an inaccurate
+	// comparison of the current time.
+	timeDriftCheckTimeout = 100 * time.Millisecond
+
+	// parallelRoutines indicates how many parallel queries we should run to peer nodes
+	parallelRoutines = 20
 )
 
 // timeDriftChecker is a checker that verifies that the time difference between
@@ -133,16 +141,39 @@ func (c *timeDriftChecker) check(ctx context.Context, r health.Reporter) (err er
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	nodesC := make(chan serf.Member, len(nodes))
 	for _, node := range nodes {
-		drift, err := c.getTimeDrift(ctx, node)
-		if err != nil {
-			log.WithError(err).Debug("Failed to get time drift.")
-			continue
-		}
-		if isDriftHigh(drift) {
-			r.Add(c.failureProbe(node, drift))
-		}
+		nodesC <- node
 	}
+	close(nodesC)
+
+	var mutex sync.Mutex
+
+	var wg sync.WaitGroup
+
+	wg.Add(parallelRoutines)
+
+	for i := 0; i < parallelRoutines; i++ {
+		go func() {
+			for node := range nodesC {
+				drift, err := c.getTimeDrift(ctx, node)
+				if err != nil {
+					log.WithError(err).Debug("Failed to get time drift.")
+					continue
+				}
+
+				if isDriftHigh(drift) {
+					mutex.Lock()
+					r.Add(c.failureProbe(node, drift))
+					mutex.Unlock()
+				}
+			}
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
 	return nil
 }
 
@@ -180,6 +211,11 @@ func (c *timeDriftChecker) getTimeDrift(ctx context.Context, node serf.Member) (
 	}
 
 	queryStart := c.Clock.Now().UTC()
+
+	// if the RPC call takes a long duration it will result in an inaccurate comparison. Timeout the RPC
+	// call to reduce false positives on a slow server.
+	ctx, cancel := context.WithTimeout(ctx, timeDriftCheckTimeout)
+	defer cancel()
 
 	// Send "time" request to the specified node.
 	peerResponse, err := agentClient.Time(ctx, &pb.TimeRequest{})

--- a/monitoring/timedrift_test.go
+++ b/monitoring/timedrift_test.go
@@ -57,6 +57,8 @@ func (s *TimeDriftSuite) TestTimeDriftChecker(c *check.C) {
 		times map[string]time.Time
 		// result is the time drift check result.
 		result []*agentpb.Probe
+		// slow indicates the server should respond slowly
+		slow bool
 	}{
 		{
 			comment: "Acceptable time drift",
@@ -116,6 +118,18 @@ func (s *TimeDriftSuite) TestTimeDriftChecker(c *check.C) {
 				s.c.failureProbe(node3, driftOverThreshold()),
 			},
 		},
+		{
+			comment: "Time drift takes too long to respond silently discarding results",
+			slow:    true,
+			nodes:   []serf.Member{node1, node2, node3},
+			times: map[string]time.Time{
+				node2.Name: s.clock.Now().Add(-driftOverThreshold()),
+				node3.Name: s.clock.Now().Add(driftOverThreshold()),
+			},
+			result: []*agentpb.Probe{
+				s.c.successProbe(),
+			},
+		},
 	}
 	for _, test := range tests {
 		checker := &timeDriftChecker{
@@ -128,7 +142,14 @@ func (s *TimeDriftSuite) TestTimeDriftChecker(c *check.C) {
 			clients:     newClientsCache(c, test.times),
 		}
 		var probes health.Probes
-		checker.Check(context.TODO(), &probes)
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		if test.slow {
+			cancel()
+		}
+
+		checker.Check(ctx, &probes)
 		c.Assert(probes.GetProbes(), check.DeepEquals, test.result,
 			check.Commentf(test.comment))
 	}
@@ -166,6 +187,11 @@ func (a *mockedTimeAgentClient) LastSeen(ctx context.Context,
 }
 
 func (a *mockedTimeAgentClient) Time(ctx context.Context, req *agentpb.TimeRequest) (*agentpb.TimeResponse, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
 	return &agentpb.TimeResponse{
 		Timestamp: agentpb.NewTimeToProto(a.time),
 	}, nil


### PR DESCRIPTION
Backport initial 1k node scaling work to 6.1.x branch.

Note: This backport is by customer request, but it is not our intention to fully maintain 1k node support or make available all 1k node support patches on the 6.1 LTS release.