### PR TITLE
[6.1] fix missing line from nethealth RxQueue ports

### DIFF
--- a/lib/nethealth/nethealth.go
+++ b/lib/nethealth/nethealth.go
@@ -171,7 +171,7 @@ func (c Config) New() (*Server, error) {
 		promPeerRequest: promPeerRequest,
 		selector:        labelSelector,
 		triggerResync:   make(chan bool, 1),
-		rxMessage:       make(chan messageWrapper, 100),
+		rxMessage:       make(chan messageWrapper, RxQueueSize),
 		peers:           make(map[string]*peer),
 		addrToPeer:      make(map[string]string),
 	}, nil


### PR DESCRIPTION
Apparently I made a mistake in the ports to 6.1/7.0 that missed the line that actually uses the adjusted queue size.