### PR TITLE
Update system pods check

### DIFF
--- a/lib/kubernetes/constants.go
+++ b/lib/kubernetes/constants.go
@@ -19,10 +19,4 @@ package kubernetes
 const (
 	// AllNamespaces can be used to query pods in all namespaces.
 	AllNamespaces = ""
-
-	// NamespaceKubeSystem specifies kube-system namespace.
-	NamespaceKubeSystem = "kube-system"
-
-	// NamespaceMonitoring specifies monitoring namespace.
-	NamespaceMonitoring = "monitoring"
 )

--- a/lib/kubernetes/constants.go
+++ b/lib/kubernetes/constants.go
@@ -16,5 +16,13 @@ limitations under the License.
 
 package kubernetes
 
-// AllNamespaces can be used to query pods in all namespaces.
-const AllNamespaces = ""
+const (
+	// AllNamespaces can be used to query pods in all namespaces.
+	AllNamespaces = ""
+
+	// NamespaceKubeSystem specifies kube-system namespace.
+	NamespaceKubeSystem = "kube-system"
+
+	// NamespaceMonitoring specifies monitoring namespace.
+	NamespaceMonitoring = "monitoring"
+)

--- a/monitoring/timedrift_test.go
+++ b/monitoring/timedrift_test.go
@@ -19,6 +19,7 @@ package monitoring
 import (
 	"context"
 	"net"
+	"sort"
 	"time"
 
 	"github.com/gravitational/satellite/agent"
@@ -145,12 +146,12 @@ func (s *TimeDriftSuite) TestTimeDriftChecker(c *check.C) {
 		var probes health.Probes
 
 		ctx, cancel := context.WithCancel(context.Background())
-
 		if test.slow {
 			cancel()
 		}
 
 		checker.Check(ctx, &probes)
+		sort.Sort(health.ByDetail(probes))
 		c.Assert(probes.GetProbes(), check.DeepEquals, test.result,
 			check.Commentf(test.comment))
 	}


### PR DESCRIPTION
## Description
This PR modifies the system pods check to query only the kube-system and monitoring namespaces. This will help  reduce the load on etcd if there are a large number of pods in user namespaces.