### PR TITLE
[7.0.x] Update system pods check

### DIFF
--- a/lib/kubernetes/constants.go
+++ b/lib/kubernetes/constants.go
@@ -16,5 +16,7 @@ limitations under the License.
 
 package kubernetes
 
-// AllNamespaces can be used to query pods in all namespaces.
-const AllNamespaces = ""
+const (
+	// AllNamespaces can be used to query pods in all namespaces.
+	AllNamespaces = ""
+)

--- a/monitoring/system_pods.go
+++ b/monitoring/system_pods.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/gravitational/satellite/agent/health"
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
-	"github.com/gravitational/satellite/lib/kubernetes"
 	"github.com/gravitational/satellite/utils"
 
 	"github.com/gravitational/trace"
@@ -35,6 +34,8 @@ import (
 type SystemPodsConfig struct {
 	// KubeConfig specifies kubernetes access configuration.
 	*KubeConfig
+	// Namespaces specifies the list of namespaces to query for critical pods.
+	Namespaces []string
 }
 
 // checkAndSetDefaults validates that this configuration is correct and sets
@@ -98,16 +99,20 @@ func (r *systemPodsChecker) check(ctx context.Context, reporter health.Reporter)
 
 // getPods returns a list of the local pods that have the
 // `gravitational.io/critical-pod` label.
-func (r *systemPodsChecker) getPods() ([]corev1.Pod, error) {
+func (r *systemPodsChecker) getPods() (pods []corev1.Pod, err error) {
 	opts := metav1.ListOptions{
 		LabelSelector: systemPodsSelector.String(),
 	}
-	pods, err := r.Client.CoreV1().Pods(kubernetes.AllNamespaces).List(opts)
-	if err != nil {
-		return nil, utils.ConvertError(err)
+
+	for _, namespace := range r.Namespaces {
+		podList, err := r.Client.CoreV1().Pods(namespace).List(opts)
+		if err != nil {
+			return pods, utils.ConvertError(err)
+		}
+		pods = append(pods, podList.Items...)
 	}
 
-	return pods.Items, nil
+	return pods, nil
 }
 
 // verifyPods verifies the pods are in a valid state. Reports a failed probe for


### PR DESCRIPTION
## Description
This PR modifies the system pods check to query only select namespaces for critical system pods. This will help reduce the load on etcd if there are a large number of pods in user namespaces.

## Linked tickets and PRs
* Ports https://github.com/gravitational/satellite/pull/278