### PR TITLE
Update cluster membership interface

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -281,46 +281,6 @@ func (r *agent) Start() error {
 	return nil
 }
 
-// IsMember returns true if this agent is a member of the serf cluster
-func (r *agent) IsMember() (ok bool, err error) {
-	client, err := r.newSerfClientFunc()
-	if err != nil {
-		return false, trace.Wrap(err)
-	}
-	defer client.Close()
-	members, err := client.Members()
-	if err != nil {
-		return false, trace.Wrap(err, "failed to retrieve members")
-	}
-	// if we're the only one, consider that we're not in the cluster yet
-	// (cause more often than not there are more than 1 member)
-	if len(members) == 1 && members[0].Name == r.Name {
-		return false, nil
-	}
-	for _, member := range members {
-		if member.Name == r.Name {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-// Join attempts to join a serf cluster identified by peers.
-func (r *agent) Join(peers []string) error {
-	client, err := r.newSerfClientFunc()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	defer client.Close()
-	noReplay := false
-	numJoined, err := client.Join(peers, noReplay)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	log.Infof("Joined %d nodes.", numJoined)
-	return nil
-}
-
 // Close stops all background activity and releases the agent's resources.
 func (r *agent) Close() (err error) {
 	r.rpc.Stop()

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -211,52 +211,6 @@ func (r *AgentSuite) TestAgentProvidesStatus(c *C) {
 	}
 }
 
-// TestIsMember validates that an agent can correctly identify if it is a
-// cluster member.
-func (r *AgentSuite) TestIsMember(c *C) {
-	var testCases = []struct {
-		comment      CommentInterface
-		expected     bool
-		membership   *mockClusterMembership
-		agentConfigs []testAgentConfig
-	}{
-		{
-			comment:    Commentf("Expected node unable to be member of a single node cluster."),
-			expected:   false,
-			membership: newMockClusterMembership(),
-			agentConfigs: []testAgentConfig{
-				{node: "node-1"},
-			},
-		},
-		{
-			comment:    Commentf("Expected node to be member of a cluster."),
-			expected:   true,
-			membership: newMockClusterMembership(),
-			agentConfigs: []testAgentConfig{
-				{node: "node-1"},
-				{node: "node-2"},
-			},
-		},
-	}
-
-	for _, testCase := range testCases {
-		agents := make([]*agent, 0, len(testCase.agentConfigs))
-		for _, agentConfig := range testCase.agentConfigs {
-			agent, err := r.newAgent(agentConfig, testCase.membership)
-			c.Assert(err, IsNil, testCase.comment)
-			agents = append(agents, agent)
-		}
-
-		test.WithTimeout(func(ctx context.Context) {
-			for _, agent := range agents {
-				ok, err := agent.IsMember()
-				c.Assert(err, IsNil, testCase.comment)
-				c.Assert(ok, Equals, testCase.expected, testCase.comment)
-			}
-		})
-	}
-}
-
 // TestRecordLocalTimeline validates that an agent correctly records events
 // in to it's local timeline.
 func (r *AgentSuite) TestRecordLocalTimeline(c *C) {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Gravitational, Inc.
+Copyright 2016-2020 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package agent
 import (
 	"context"
 	"errors"
-	"net"
 	"os"
 	"path/filepath"
 	"sort"
@@ -83,14 +82,14 @@ func (r *AgentSuite) TestAgentProvidesStatus(c *C) {
 					{
 						Name:   "node-1",
 						Status: pb.NodeStatus_Running,
-						MemberStatus: &pb.MemberStatus{Name: "node-1", Addr: "<nil>:0",
+						MemberStatus: &pb.MemberStatus{Name: "node-1", Addr: "node-1",
 							Tags: tags{"role": string(RoleNode)}, Status: pb.MemberStatus_Alive},
 						Probes: []*pb.Probe{healthyProbe},
 					},
 					{
 						Name:   "node-2",
 						Status: pb.NodeStatus_Running,
-						MemberStatus: &pb.MemberStatus{Name: "node-2", Addr: "<nil>:0",
+						MemberStatus: &pb.MemberStatus{Name: "node-2", Addr: "node-2",
 							Tags: tags{"role": string(RoleNode)}, Status: pb.MemberStatus_Alive},
 						Probes: []*pb.Probe{healthyProbe},
 					},
@@ -122,14 +121,14 @@ func (r *AgentSuite) TestAgentProvidesStatus(c *C) {
 					{
 						Name:   "master-1",
 						Status: pb.NodeStatus_Running,
-						MemberStatus: &pb.MemberStatus{Name: "master-1", Addr: "<nil>:0",
+						MemberStatus: &pb.MemberStatus{Name: "master-1", Addr: "master-1",
 							Tags: tags{"role": string(RoleMaster)}, Status: pb.MemberStatus_Alive},
 						Probes: []*pb.Probe{healthyProbe},
 					},
 					{
 						Name:   "node-1",
 						Status: pb.NodeStatus_Degraded,
-						MemberStatus: &pb.MemberStatus{Name: "node-1", Addr: "<nil>:0",
+						MemberStatus: &pb.MemberStatus{Name: "node-1", Addr: "node-1",
 							Tags: tags{"role": string(RoleNode)}, Status: pb.MemberStatus_Alive},
 						Probes: []*pb.Probe{failedProbe},
 					},
@@ -152,37 +151,6 @@ func (r *AgentSuite) TestAgentProvidesStatus(c *C) {
 			},
 		},
 		{
-			comment: Commentf("Expected to ignore inactive members."),
-			expected: &pb.SystemStatus{
-				Timestamp: pb.NewTimeToProto(r.clock.Now()),
-				Status:    pb.SystemStatus_Running,
-				Nodes: []*pb.NodeStatus{
-					{
-						Name:   "master-1",
-						Status: pb.NodeStatus_Running,
-						MemberStatus: &pb.MemberStatus{Name: "master-1", Addr: "<nil>:0",
-							Tags: tags{"role": string(RoleMaster)}, Status: pb.MemberStatus_Alive},
-						Probes: []*pb.Probe{healthyProbe},
-					},
-				},
-			},
-			membership: newMockClusterMembership(),
-			agentConfigs: []testAgentConfig{
-				{
-					node:         "master-1",
-					role:         RoleMaster,
-					memberStatus: MemberAlive,
-					checkers:     []health.Checker{healthyTest},
-				},
-				{
-					node:         "node-1",
-					role:         RoleNode,
-					memberStatus: MemberLeft,
-					checkers:     []health.Checker{failedTest},
-				},
-			},
-		},
-		{
 			comment: Commentf("Expected all systems running."),
 			expected: &pb.SystemStatus{
 				Timestamp: pb.NewTimeToProto(r.clock.Now()),
@@ -191,14 +159,14 @@ func (r *AgentSuite) TestAgentProvidesStatus(c *C) {
 					{
 						Name:   "master-1",
 						Status: pb.NodeStatus_Running,
-						MemberStatus: &pb.MemberStatus{Name: "master-1", Addr: "<nil>:0",
+						MemberStatus: &pb.MemberStatus{Name: "master-1", Addr: "master-1",
 							Tags: tags{"role": string(RoleMaster)}, Status: pb.MemberStatus_Alive},
 						Probes: []*pb.Probe{healthyProbe},
 					},
 					{
 						Name:   "node-1",
 						Status: pb.NodeStatus_Running,
-						MemberStatus: &pb.MemberStatus{Name: "node-1", Addr: "<nil>:0",
+						MemberStatus: &pb.MemberStatus{Name: "node-1", Addr: "node-1",
 							Tags: tags{"role": string(RoleNode)}, Status: pb.MemberStatus_Alive},
 						Probes: []*pb.Probe{healthyProbe},
 					},
@@ -227,7 +195,6 @@ func (r *AgentSuite) TestAgentProvidesStatus(c *C) {
 		for _, agentConfig := range testCase.agentConfigs {
 			agent, err := r.newAgent(agentConfig, testCase.membership)
 			c.Assert(err, IsNil, testCase.comment)
-			c.Assert(r.becomeMember(testCase.membership, agent, agentConfig.memberStatus), IsNil, testCase.comment)
 			agents = append(agents, agent)
 		}
 
@@ -277,7 +244,6 @@ func (r *AgentSuite) TestIsMember(c *C) {
 		for _, agentConfig := range testCase.agentConfigs {
 			agent, err := r.newAgent(agentConfig, testCase.membership)
 			c.Assert(err, IsNil, testCase.comment)
-			c.Assert(r.becomeActiveMember(testCase.membership, agent), IsNil, testCase.comment)
 			agents = append(agents, agent)
 		}
 
@@ -324,7 +290,6 @@ func (r *AgentSuite) TestRecordLocalTimeline(c *C) {
 	for _, testCase := range testCases {
 		agent, err := r.newAgent(testCase.agentConfig, testCase.membership)
 		c.Assert(err, IsNil, testCase.comment)
-		c.Assert(r.becomeActiveMember(testCase.membership, agent), IsNil, testCase.comment)
 
 		test.WithTimeout(func(ctx context.Context) {
 			_, err := agent.collectLocalStatus(ctx, testCase.membership)
@@ -362,7 +327,6 @@ func (r *AgentSuite) TestRecordTimeline(c *C) {
 	for _, testCase := range testCases {
 		agent, err := r.newAgent(testCase.agentConfig, testCase.membership)
 		c.Assert(err, IsNil, testCase.comment)
-		c.Assert(r.becomeActiveMember(testCase.membership, agent), IsNil, testCase.comment)
 
 		test.WithTimeout(func(ctx context.Context) {
 			c.Assert(agent.RecordClusterEvents(ctx, testCase.events), IsNil, testCase.comment)
@@ -498,7 +462,6 @@ func (r *AgentSuite) TestProvidesTimeline(c *C) {
 		for _, masterConfig := range testCase.masterConfigs {
 			master, err := r.newAgent(masterConfig, testCase.membership)
 			c.Assert(err, IsNil, testCase.comment)
-			c.Assert(r.becomeActiveMember(testCase.membership, master), IsNil, testCase.comment)
 			masters = append(masters, master)
 		}
 
@@ -506,7 +469,6 @@ func (r *AgentSuite) TestProvidesTimeline(c *C) {
 		for _, nodeConfig := range testCase.nodeConfigs {
 			node, err := r.newAgent(nodeConfig, testCase.membership)
 			c.Assert(err, IsNil, testCase.comment)
-			c.Assert(r.becomeActiveMember(testCase.membership, node), IsNil, testCase.comment)
 			nodes = append(nodes, node)
 		}
 
@@ -563,10 +525,11 @@ func (r *AgentSuite) newAgent(config testAgentConfig, client *mockClusterMembers
 	config.setDefaults()
 
 	agentConfig := Config{
-		Cache: inmemory.New(),
-		Name:  config.node,
-		Clock: config.clock,
-		Tags:  tags{"role": string(config.role)},
+		Cache:   inmemory.New(),
+		Name:    config.node,
+		Clock:   config.clock,
+		Tags:    tags{"role": string(config.role)},
+		DialRPC: client.dial,
 	}
 
 	var lastSeen *ttlmap.TTLMap
@@ -585,9 +548,7 @@ func (r *AgentSuite) newAgent(config testAgentConfig, client *mockClusterMembers
 		newSerfClientFunc:       newClusterMembershipFrom(client),
 	}
 
-	if err := r.becomeActiveMember(client, agent); err != nil {
-		return nil, trace.Wrap(err)
-	}
+	client.addAgent(agent)
 
 	return agent, nil
 }
@@ -664,7 +625,7 @@ func (r byName) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
 func (r byName) Less(i, j int) bool { return r[i].Name < r[j].Name }
 
 type mockClusterMembership struct {
-	members map[string]membership.ClusterMember
+	agents map[string]*agent
 }
 
 func newClusterMembershipFrom(client *mockClusterMembership) func() (membership.ClusterMembership, error) {
@@ -675,27 +636,47 @@ func newClusterMembershipFrom(client *mockClusterMembership) func() (membership.
 
 func newMockClusterMembership() *mockClusterMembership {
 	return &mockClusterMembership{
-		members: make(map[string]membership.ClusterMember),
+		agents: make(map[string]*agent),
 	}
 }
 
 // Members returns the list of cluster members.
-func (r mockClusterMembership) Members() ([]membership.ClusterMember, error) {
-	members := make([]membership.ClusterMember, 0, len(r.members))
-	for _, member := range r.members {
-		if MemberStatus(member.Status()) == MemberAlive {
-			members = append(members, member)
-		}
+func (r mockClusterMembership) Members() ([]*pb.MemberStatus, error) {
+	members := make([]*pb.MemberStatus, 0, len(r.agents))
+	for _, agent := range r.agents {
+		members = append(members, memberFromAgent(agent))
 	}
 	return members, nil
 }
 
 // FindMember finds the member with the specified name.
-func (r mockClusterMembership) FindMember(name string) (membership.ClusterMember, error) {
-	if member, ok := r.members[name]; ok {
-		return member, nil
+func (r mockClusterMembership) FindMember(name string) (*pb.MemberStatus, error) {
+	if agent, ok := r.agents[name]; ok {
+		return memberFromAgent(agent), nil
 	}
 	return nil, trace.BadParameter("node does not have membership")
+}
+
+// addAgent adds the agent as a member to the mock cluster.
+func (r *mockClusterMembership) addAgent(agent *agent) {
+	r.agents[agent.Name] = agent
+}
+
+// dial returns a new mockClient for the member specified by name.
+func (r *mockClusterMembership) dial(_ context.Context, name string) (client.Client, error) {
+	if agent, exists := r.agents[name]; exists {
+		return newMockClient(agent)
+	}
+	return nil, trace.NotFound("%s does not exist in this cluster", name)
+}
+
+// memberFromAgent constructs a new member from the provided agent.
+func memberFromAgent(agent *agent) *pb.MemberStatus {
+	return pb.NewMemberStatus(
+		agent.Name,
+		agent.Name, // mock dial function will use name to dial node
+		agent.Tags,
+	)
 }
 
 // Close closes the client.
@@ -718,61 +699,6 @@ func (r mockClusterMembership) UpdateTags(tags map[string]string, delTags []stri
 // GetCoordinate returns the Serf Coordinate for a specific node
 func (r mockClusterMembership) GetCoordinate(node string) (*coordinate.Coordinate, error) {
 	return nil, trace.NotImplemented("not implemented")
-}
-
-func (r *AgentSuite) becomeActiveMember(membership *mockClusterMembership, agent *agent) error {
-	return r.becomeMember(membership, agent, MemberAlive)
-}
-
-func (r *AgentSuite) becomeMember(membership *mockClusterMembership, agent *agent, status MemberStatus) error {
-	// Add agent to cluster membership.
-	membership.members[agent.Name] = newMockClusterMember(agent, status)
-
-	return nil
-}
-
-type mockClusterMember struct {
-	agent  *agent
-	status MemberStatus
-}
-
-// newMockClusterMember initializes a new cluster member and adds the agent
-// to the cluster membership.
-func newMockClusterMember(agent *agent, status MemberStatus) *mockClusterMember {
-	return &mockClusterMember{
-		agent:  agent,
-		status: status,
-	}
-}
-
-// Dial attempts to create client connect to member.
-func (r mockClusterMember) Dial(ctx context.Context, caFile, certFile, keyFile string) (client.Client, error) {
-	return newMockClient(r.agent)
-}
-
-// Name gets the member's name.
-func (r mockClusterMember) Name() string {
-	return r.agent.Name
-}
-
-// Addr gets the member's address.
-func (r mockClusterMember) Addr() net.IP {
-	return nil
-}
-
-// Port gets the member's gossip port.
-func (r mockClusterMember) Port() uint16 {
-	return 0
-}
-
-// Tags gets the member's tags.
-func (r mockClusterMember) Tags() map[string]string {
-	return r.agent.Tags
-}
-
-// Status gets the member's status.
-func (r mockClusterMember) Status() string {
-	return string(r.status)
 }
 
 type mockClient struct {

--- a/agent/proto/agentpb/status.go
+++ b/agent/proto/agentpb/status.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Gravitational, Inc.
+Copyright 2016-2020 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,6 +22,16 @@ import "github.com/gravitational/trace"
 // EmptyStatus returns an empty system status
 func EmptyStatus() *SystemStatus {
 	return &SystemStatus{Status: SystemStatus_Unknown}
+}
+
+// NewMemberStatus constructs a new MemberStatus.
+func NewMemberStatus(name, addr string, tags map[string]string) *MemberStatus {
+	return &MemberStatus{
+		Name:   name,
+		Addr:   addr,
+		Status: MemberStatus_Alive,
+		Tags:   tags,
+	}
 }
 
 // encoding.TextMarshaler

--- a/agent/server.go
+++ b/agent/server.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Gravitational, Inc.
+Copyright 2016-2020 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -346,8 +346,6 @@ type Agent interface {
 	Start() error
 	// Close stops background activity and releases resources.
 	Close() error
-	// Join makes an attempt to join a cluster specified by the list of peers.
-	Join(peers []string) error
 	// Time reports the current server time.
 	Time() time.Time
 	// LocalStatus reports the health status of the local agent node.
@@ -364,8 +362,6 @@ type Agent interface {
 	RecordClusterEvents(ctx context.Context, events []*pb.TimelineEvent) error
 	// RecordLocalEvents records the events into the local timeline.
 	RecordLocalEvents(ctx context.Context, events []*pb.TimelineEvent) error
-	// IsMember returns whether this agent is already a member of serf cluster
-	IsMember() (ok bool, err error)
 	// GetConfig returns the agent configuration.
 	GetConfig() Config
 	// CheckerRepository allows to add checks to the agent.

--- a/agent/status_test.go
+++ b/agent/status_test.go
@@ -18,10 +18,8 @@ package agent
 
 import (
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
-	"github.com/gravitational/satellite/lib/membership"
 	"github.com/gravitational/satellite/lib/test"
 
-	serf "github.com/hashicorp/serf/client"
 	. "gopkg.in/check.v1"
 )
 
@@ -51,9 +49,9 @@ func (*StatusSuite) TestSetsSystemStatusFromMemberStatuses(c *C) {
 		},
 	}
 	actual := status
-	members := []membership.ClusterMember{
-		membership.SerfMember{Member: &serf.Member{Name: "foo"}},
-		membership.SerfMember{Member: &serf.Member{Name: "bar"}},
+	members := []*pb.MemberStatus{
+		{Name: "foo"},
+		{Name: "bar"},
 	}
 	setSystemStatus(&actual, members)
 
@@ -96,9 +94,9 @@ func (*StatusSuite) TestSetsSystemStatusFromNodeStatuses(c *C) {
 	}
 
 	actual := status
-	members := []membership.ClusterMember{
-		membership.SerfMember{Member: &serf.Member{Name: "foo"}},
-		membership.SerfMember{Member: &serf.Member{Name: "bar"}},
+	members := []*pb.MemberStatus{
+		{Name: "foo"},
+		{Name: "bar"},
 	}
 	setSystemStatus(&actual, members)
 
@@ -131,9 +129,9 @@ func (*StatusSuite) TestDetectsNoMaster(c *C) {
 	}
 
 	actual := status
-	members := []membership.ClusterMember{
-		membership.SerfMember{Member: &serf.Member{Name: "foo"}},
-		membership.SerfMember{Member: &serf.Member{Name: "bar"}},
+	members := []*pb.MemberStatus{
+		{Name: "foo"},
+		{Name: "bar"},
 	}
 	setSystemStatus(&actual, members)
 
@@ -168,9 +166,9 @@ func (*StatusSuite) TestSetsOkSystemStatus(c *C) {
 		},
 	}
 	actual := status
-	members := []membership.ClusterMember{
-		membership.SerfMember{Member: &serf.Member{Name: "foo"}},
-		membership.SerfMember{Member: &serf.Member{Name: "bar"}},
+	members := []*pb.MemberStatus{
+		{Name: "foo"},
+		{Name: "bar"},
 	}
 	setSystemStatus(&actual, members)
 

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Gravitational, Inc.
+Copyright 2016-2020 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -44,11 +44,6 @@ func runAgent(config *agent.Config, monitoringConfig *config, peers []string) er
 	}
 	if err = monitoringAgent.Start(); err != nil {
 		return trace.Wrap(err)
-	}
-	if len(peers) > 0 {
-		if err = monitoringAgent.Join(peers); err != nil {
-			return trace.Wrap(err, "failed to join serf cluster")
-		}
 	}
 
 	signalc := make(chan os.Signal, 2)

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -22,8 +22,10 @@ import (
 	"syscall"
 
 	"github.com/gravitational/satellite/agent"
+	"github.com/gravitational/satellite/lib/membership"
 
 	"github.com/gravitational/trace"
+	serf "github.com/hashicorp/serf/client"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -32,6 +34,14 @@ func runAgent(config *agent.Config, monitoringConfig *config, peers []string) er
 	if len(peers) > 0 {
 		log.Infof("initial cluster=%v", peers)
 	}
+
+	cluster, err := membership.NewSerfCluster(&serf.Config{
+		Addr: monitoringConfig.serfRPCAddr,
+	})
+	if err != nil {
+		return trace.Wrap(err, "failed to initialize serf cluster membership service")
+	}
+	config.Cluster = cluster
 
 	monitoringAgent, err := agent.New(config)
 	if err != nil {

--- a/cmd/agent/checkers.go
+++ b/cmd/agent/checkers.go
@@ -83,7 +83,7 @@ func addToMaster(node agent.Agent, config *config, kubeConfig monitoring.KubeCon
 
 	latencyChecker, err := latency.NewChecker(&latency.Config{
 		NodeName:      node.GetConfig().NodeName,
-		KubeClient:    kubeConfig.Client,
+		Cluster:       node.GetConfig().Cluster,
 		LatencyClient: nethealth.NewClient(nethealth.DefaultNethealthSocket),
 	})
 	if err != nil {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Gravitational, Inc.
+Copyright 2016-2020 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/gravitational/version"
 
-	serf "github.com/hashicorp/serf/client"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
@@ -157,10 +156,6 @@ func run() error {
 			CAFile:      *cagentCAFile,
 			CertFile:    *cagentCertFile,
 			KeyFile:     *cagentKeyFile,
-
-			SerfConfig: serf.Config{
-				Addr: *cagentSerfRPCAddr,
-			},
 			TimelineConfig: sqlite.Config{
 				DBPath:            *cagentTimelineDir,
 				RetentionDuration: *cagentRetention,

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -164,7 +164,6 @@ func run() error {
 		monitoringConfig := &config{
 			role:                 agent.Role(agentRole),
 			serfRPCAddr:          *cagentSerfRPCAddr,
-			serfMemberName:       agentConfig.Name,
 			kubeconfigPath:       *cagentKubeconfig,
 			kubeletAddr:          *cagentKubeletAddr,
 			dockerAddr:           *cagentDockerAddr,

--- a/lib/membership/membership.go
+++ b/lib/membership/membership.go
@@ -18,10 +18,7 @@ limitations under the License.
 package membership
 
 import (
-	"context"
-	"net"
-
-	"github.com/gravitational/satellite/lib/rpc/client"
+	pb "github.com/gravitational/satellite/agent/proto/agentpb"
 
 	"github.com/hashicorp/serf/coordinate"
 )
@@ -29,9 +26,9 @@ import (
 // ClusterMembership is interface to interact with a cluster membership service.
 type ClusterMembership interface {
 	// Members returns the list of cluster members.
-	Members() ([]ClusterMember, error)
+	Members() ([]*pb.MemberStatus, error)
 	// FindMember finds the member with the specified name.
-	FindMember(name string) (ClusterMember, error)
+	FindMember(name string) (*pb.MemberStatus, error)
 	// Close closes the client.
 	Close() error
 	// Join attempts to join an existing cluster identified by peers.
@@ -42,20 +39,4 @@ type ClusterMembership interface {
 	UpdateTags(tags map[string]string, delTags []string) error
 	// GetCoordinate returns the Serf Coordinate for a specific node
 	GetCoordinate(node string) (*coordinate.Coordinate, error)
-}
-
-// ClusterMember is interface to interact with a cluster member.
-type ClusterMember interface {
-	// Dial attempts to create client connect to member.
-	Dial(ctx context.Context, caFile, certFile, keyFile string) (client.Client, error)
-	// Name gets the member's name.
-	Name() string
-	// Addr gets the member's address.
-	Addr() net.IP
-	// Port gets the member's gossip port.
-	Port() uint16
-	// Tags gets the member's tags.
-	Tags() map[string]string
-	// Status gets the member's status.
-	Status() string
 }

--- a/lib/membership/membership.go
+++ b/lib/membership/membership.go
@@ -14,29 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package membership provides interface for cluster membership management.
+// Package membership provides an interface for querying cluster membership
+// status.
 package membership
 
 import (
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
-
-	"github.com/hashicorp/serf/coordinate"
 )
 
-// ClusterMembership is interface to interact with a cluster membership service.
-type ClusterMembership interface {
+// Cluster interface is used to query cluster members.
+type Cluster interface {
 	// Members returns the list of cluster members.
 	Members() ([]*pb.MemberStatus, error)
-	// FindMember finds the member with the specified name.
-	FindMember(name string) (*pb.MemberStatus, error)
-	// Close closes the client.
-	Close() error
-	// Join attempts to join an existing cluster identified by peers.
-	// Replay controls if previous user events are replayed once this node has joined the cluster.
-	// Returns the number of nodes joined.
-	Join(peers []string, replay bool) (int, error)
-	// UpdateTags will modify the tags on a running member.
-	UpdateTags(tags map[string]string, delTags []string) error
-	// GetCoordinate returns the Serf Coordinate for a specific node
-	GetCoordinate(node string) (*coordinate.Coordinate, error)
+	// Member returns the member with the specified name.
+	Member(name string) (*pb.MemberStatus, error)
 }

--- a/lib/membership/serf.go
+++ b/lib/membership/serf.go
@@ -21,97 +21,100 @@ import (
 
 	"github.com/gravitational/trace"
 	serf "github.com/hashicorp/serf/client"
-	"github.com/hashicorp/serf/coordinate"
+	"github.com/sirupsen/logrus"
 )
 
-// Client is an rpc client used to make requests to a serf agent.
-type Client struct {
-	client *serf.RPCClient
+// SerfCluster can query members of the Serf cluster.
+//
+// Implements Cluster
+type SerfCluster struct {
+	// config specifies the information needed to create a client connection
+	// to the local serf agent.
+	config *serf.Config
 }
 
-// NewSerfClient returns a new serf client for the specified configuration.
-func NewSerfClient(config serf.Config) (*Client, error) {
-	client, err := serf.ClientFromConfig(&config)
-	if err != nil {
-		return nil, trace.Wrap(err)
+// NewSerfCluster returns a new Serf cluster.
+func NewSerfCluster(config *serf.Config) (*SerfCluster, error) {
+	if config == nil {
+		return nil, trace.BadParameter("serf config must be provided")
 	}
-	return &Client{
-		client: client,
+	if config.Addr == "" {
+		return nil, trace.BadParameter("serf addr must be provided")
+	}
+	return &SerfCluster{
+		config: config,
 	}, nil
 }
 
-// Members lists members of the serf cluster.
-func (r *Client) Members() ([]*pb.MemberStatus, error) {
-	members, err := r.client.Members()
+// Members lists the members of the Serf cluster.
+// Inactive members will be filtered out.
+func (r *SerfCluster) Members() ([]*pb.MemberStatus, error) {
+	return r.members()
+}
+
+// members lists the members of the Serf Cluster.
+// Inactive members will be filtered out.
+func (r *SerfCluster) members() (clusterMembers []*pb.MemberStatus, err error) {
+	client, err := serf.ClientFromConfig(r.config)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return clusterMembers, trace.Wrap(err, "failed to create Serf client")
 	}
+	defer client.Close()
 
-	// NOTE: is it okay to filter out inactive nodes in this function?
-	// When do we want to use a list of members including inactive nodes?
-	members = filterLeft(members)
+	serfMembers, err := client.Members()
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to fetch Serf members")
+	}
+	serfMembers = filterInactive(serfMembers)
 
-	clusterMembers := make([]*pb.MemberStatus, 0, len(members))
-	for _, member := range members {
-		status := pb.NewMemberStatus(member.Name, member.Addr.String(), member.Tags)
+	for _, serfMember := range serfMembers {
+		status := pb.NewMemberStatus(serfMember.Name, serfMember.Addr.String(), serfMember.Tags)
 		clusterMembers = append(clusterMembers, status)
 	}
+
 	return clusterMembers, nil
 }
 
-// FindMember finds serf member with the specified name.
-func (r *Client) FindMember(name string) (member *pb.MemberStatus, err error) {
-	members, err := r.Members()
+// Member returns the member with the specified name.
+// Returns NotFound if the specified member is not an active member of the
+// Serf cluster.
+func (r *SerfCluster) Member(name string) (member *pb.MemberStatus, err error) {
+	members, err := r.members()
 	if err != nil {
-		return member, trace.Wrap(err)
+		return member, trace.Wrap(err, "failed to get cluster members")
 	}
+
 	for _, member := range members {
 		if member.Name == name {
 			return member, nil
 		}
 	}
-	return member, trace.NotFound("serf member %q not found", name)
+
+	return member, trace.NotFound("member %s is not an active member of the cluster", name)
 }
 
-// Stop cancels the serf event delivery and removes the subscription.
-func (r *Client) Stop(handle serf.StreamHandle) error {
-	return r.client.Stop(handle)
-}
-
-// Join attempts to join an existing serf cluster identified by peers.
-// Replay controls if previous user events are replayed once this node has joined the cluster.
-// Returns the number of nodes joined
-func (r *Client) Join(peers []string, replay bool) (int, error) {
-	return r.client.Join(peers, replay)
-}
-
-// UpdateTags will modify the tags on a running serf agent
-func (r *Client) UpdateTags(tags map[string]string, delTags []string) error {
-	return r.client.UpdateTags(tags, delTags)
-}
-
-// Close closes the client
-func (r *Client) Close() error {
-	if r.client.IsClosed() {
-		return nil
-	}
-	return r.client.Close()
-}
-
-// GetCoordinate returns the Serf Coordinate for a specific node
-func (r *Client) GetCoordinate(node string) (*coordinate.Coordinate, error) {
-	return r.client.GetCoordinate(node)
-}
-
-// filterLeft filters out members that have left the serf cluster
-func filterLeft(members []serf.Member) (result []serf.Member) {
-	result = make([]serf.Member, 0, len(members))
+// filterInactive filters out Serf members that are not "alive".
+func filterInactive(members []serf.Member) (result []serf.Member) {
 	for _, member := range members {
-		if MemberStatus(member.Status) == MemberLeft {
-			// Skip
+		if memberStatus(member.Status) != memberAlive {
+			logrus.WithField("member", member.Name).Debug("Inactive member has been filtered.")
 			continue
 		}
 		result = append(result, member)
 	}
 	return result
 }
+
+// memberStatus describes the state of a Serf node.
+type memberStatus string
+
+const (
+	// memberAlive indicates serf member is active.
+	memberAlive memberStatus = "alive"
+	// memberLeaving indicates serf member is in the process of leaving the cluster.
+	memberLeaving memberStatus = "leaving"
+	// memberLeft indicates serf member has left the cluster.
+	memberLeft memberStatus = "left"
+	// memberFailed indicates failure has been detected on serf member.
+	memberFailed memberStatus = "failed"
+)

--- a/lib/membership/serf.go
+++ b/lib/membership/serf.go
@@ -29,7 +29,7 @@ import (
 // Implements Cluster
 type SerfCluster struct {
 	// config specifies the information needed to create a client connection
-	// to the local serf agent.
+	// to the local Serf agent.
 	config *serf.Config
 }
 
@@ -52,7 +52,7 @@ func (r *SerfCluster) Members() ([]*pb.MemberStatus, error) {
 	return r.members()
 }
 
-// members lists the members of the Serf Cluster.
+// members lists the members of the Serf cluster.
 // Inactive members will be filtered out.
 func (r *SerfCluster) members() (clusterMembers []*pb.MemberStatus, err error) {
 	client, err := serf.ClientFromConfig(r.config)

--- a/lib/rpc/client/client.go
+++ b/lib/rpc/client/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Gravitational, Inc.
+Copyright 2016-2020 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import (
 	"github.com/gravitational/satellite/lib/rpc"
 
 	"github.com/gravitational/trace"
-	serf "github.com/hashicorp/serf/client"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -224,15 +223,15 @@ func (r *client) Close() error {
 	return r.conn.Close()
 }
 
-// DialRPC returns RPC client for the provided Serf member.
-type DialRPC func(context.Context, *serf.Member) (Client, error)
+// DialRPC returns RPC client for the provided addr.
+type DialRPC func(ctx context.Context, addr string) (Client, error)
 
-// DefaultDialRPC is a default RPC client factory function.
-// It creates a new client based on address details from the specific serf member.
+// DefaultDialRPC is the default RPC client factory function.
+// It creates a new client based on address details.
 func DefaultDialRPC(caFile, certFile, keyFile string) DialRPC {
-	return func(ctx context.Context, member *serf.Member) (Client, error) {
+	return func(ctx context.Context, addr string) (Client, error) {
 		config := Config{
-			Address:  fmt.Sprintf("%s:%d", member.Addr.String(), rpc.Port),
+			Address:  fmt.Sprintf("%s:%d", addr, rpc.Port),
 			CAFile:   caFile,
 			CertFile: certFile,
 			KeyFile:  keyFile,

--- a/monitoring/latency/latency.go
+++ b/monitoring/latency/latency.go
@@ -25,14 +25,11 @@ import (
 
 	"github.com/gravitational/satellite/agent/health"
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
-	"github.com/gravitational/satellite/utils"
+	"github.com/gravitational/satellite/lib/membership"
 
 	"github.com/gravitational/trace"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -50,8 +47,8 @@ const (
 	NamespaceMonitoring = "monitoring"
 )
 
-// LatencyClient interface provides latency summaries.
-type LatencyClient interface {
+// latencyClient interface provides latency summaries.
+type latencyClient interface {
 	// LatencySummariesMilli returns the latency summaries for each peer. The
 	// latency values represent milliseconds.
 	LatencySummariesMilli(ctx context.Context) (map[string]*dto.Summary, error)
@@ -65,10 +62,10 @@ type Config struct {
 	LatencyQuantile float64
 	// LatencyThreshold specifies the latency threshold.
 	LatencyThreshold time.Duration
-	// KubeClient specifies kubernetes clientset.
-	KubeClient kubernetes.Interface
 	// LatencyClient specifies nethealth client that provides latency metrics.
-	LatencyClient LatencyClient
+	LatencyClient latencyClient
+	// Cluster specifies cluster membership interface.
+	membership.Cluster
 }
 
 // checkAndSetDefaults validates the config and sets default values.
@@ -77,8 +74,8 @@ func (r *Config) checkAndSetDefaults() error {
 	if r.NodeName == "" {
 		errors = append(errors, trace.BadParameter("NodeName must be provided"))
 	}
-	if r.KubeClient == nil {
-		errors = append(errors, trace.BadParameter("KubeClient must be provided"))
+	if r.Cluster == nil {
+		errors = append(errors, trace.BadParameter("Cluster must be provided"))
 	}
 	if r.LatencyClient == nil {
 		errors = append(errors, trace.BadParameter("LatencyClient must be provided"))
@@ -136,12 +133,13 @@ func (r *checker) Check(ctx context.Context, reporter health.Reporter) {
 
 // check checks the latency between this and other nodes in the cluster.
 func (r *checker) check(ctx context.Context, reporter health.Reporter) error {
-	peers, err := r.getPeers()
+	members, err := r.Cluster.Members()
 	if err != nil {
-		return trace.Wrap(err, "failed to discover nethealth peers")
+		return trace.Wrap(err, "failed to query cluster members")
 	}
 
-	if len(peers) == 0 {
+	// Ignore checks if this node is the only member of the cluster.
+	if len(members) <= 1 {
 		return nil
 	}
 
@@ -150,59 +148,41 @@ func (r *checker) check(ctx context.Context, reporter health.Reporter) error {
 		return trace.Wrap(err, "failed to get latency summaries")
 	}
 
-	r.verifyLatency(filterByK8s(summaries, peers), r.LatencyQuantile, reporter)
+	for _, member := range members {
+		r.verifyLatency(summaries, member.Name, reporter)
+	}
+	// r.verifyLatency(filterByK8s(summaries, peers), r.LatencyQuantile, reporter)
 
 	return nil
 }
 
-// verifyLatency verifies the latency for each peer. Reports a failed probe if
-// the latency at the specified percentile is higher than the configured
+// verifyLatency verifies the latency for the specified node. Reports a failed
+// probe if the latency at the configured quantile is higher than the configured
 // threshold.
-func (r *checker) verifyLatency(summaries map[string]*dto.Summary, percentile float64, reporter health.Reporter) {
-	for peer, summary := range summaries {
-		latency, err := latencyAtQuantile(summary, percentile)
-		if err != nil {
-			r.WithError(err).
-				WithField("peer", peer).
-				WithField("summary", summary).
-				Warn("Failed to verify latency.")
-			continue
-		}
-
-		if latency > r.LatencyThreshold {
-			reporter.Add(failureProbe(r.NodeName, peer, latency, r.LatencyThreshold))
-		}
+func (r *checker) verifyLatency(summaries map[string]*dto.Summary, node string, reporter health.Reporter) {
+	// Skip self
+	if r.NodeName == node {
+		return
 	}
-}
 
-// getPeers returns all nethealth peers as a list of strings.
-func (r *checker) getPeers() (peers []string, err error) {
-	opts := metav1.ListOptions{
-		LabelSelector: LabelSelectorNethealth,
-		FieldSelector: fields.OneTermNotEqualSelector("spec.nodeName", r.NodeName).String(),
+	summary, exists := summaries[node]
+	if !exists {
+		r.WithField("node", node).Warn("Missing latency metrics for node.")
+		return
 	}
-	pods, err := r.KubeClient.CoreV1().Pods(NamespaceMonitoring).List(opts)
+
+	latency, err := latencyAtQuantile(summary, r.LatencyQuantile)
 	if err != nil {
-		return peers, utils.ConvertError(err)
+		r.WithError(err).
+			WithField("node", node).
+			WithField("summary", summary).
+			Warn("Failed to verify latency.")
+		return
 	}
-	for _, pod := range pods.Items {
-		peers = append(peers, pod.Spec.NodeName)
-	}
-	return peers, nil
-}
 
-// filterByK8s removes entires for nodes that are not specified in the provided
-// list of nodes.
-func filterByK8s(summaries map[string]*dto.Summary, nodes []string) (filtered map[string]*dto.Summary) {
-	filtered = make(map[string]*dto.Summary)
-	for _, node := range nodes {
-		if summary, exists := summaries[node]; exists {
-			filtered[node] = summary
-			continue
-		}
-		logrus.WithField("node", node).Warn("Missing nethealth metrics for node.")
+	if latency > r.LatencyThreshold {
+		reporter.Add(failureProbe(r.NodeName, node, latency, r.LatencyThreshold))
 	}
-	return filtered
 }
 
 // latencyAtQuantile returns the latency at the specified quantile. Latency

--- a/monitoring/latency/latency.go
+++ b/monitoring/latency/latency.go
@@ -151,7 +151,6 @@ func (r *checker) check(ctx context.Context, reporter health.Reporter) error {
 	for _, member := range members {
 		r.verifyLatency(summaries, member.Name, reporter)
 	}
-	// r.verifyLatency(filterByK8s(summaries, peers), r.LatencyQuantile, reporter)
 
 	return nil
 }

--- a/monitoring/timedrift.go
+++ b/monitoring/timedrift.go
@@ -118,7 +118,7 @@ func (c *timeDriftChecker) Check(ctx context.Context, r health.Reporter) {
 		return
 	}
 	if r.NumProbes() == 0 {
-		r.Add(successProbe(c.NodeName))
+		r.Add(successProbeTimeDrift(c.NodeName))
 	}
 }
 
@@ -152,7 +152,7 @@ func (c *timeDriftChecker) check(ctx context.Context, r health.Reporter) (err er
 
 				if isDriftHigh(drift) {
 					mutex.Lock()
-					r.Add(failureProbe(c.NodeName, node.Name, drift))
+					r.Add(failureProbeTimeDrift(c.NodeName, node.Name, drift))
 					mutex.Unlock()
 				}
 			}
@@ -318,8 +318,8 @@ func isDriftHigh(drift time.Duration) bool {
 	return drift < 0 && -drift > timeDriftThreshold || drift > timeDriftThreshold
 }
 
-// successProbe constructs a probe that represents successful time drift check.
-func successProbe(node string) *pb.Probe {
+// successProbeTimeDrift constructs a probe that represents successful time drift check.
+func successProbeTimeDrift(node string) *pb.Probe {
 	return &pb.Probe{
 		Checker: timeDriftCheckerID,
 		Detail: fmt.Sprintf("time drift between %s and other nodes is within the allowed threshold of %s",
@@ -328,9 +328,9 @@ func successProbe(node string) *pb.Probe {
 	}
 }
 
-// failureProbe constructs a probe that represents failed time drift check
+// failureProbeTimeDrift constructs a probe that represents failed time drift check
 // between the specified nodes.
-func failureProbe(node1, node2 string, drift time.Duration) *pb.Probe {
+func failureProbeTimeDrift(node1, node2 string, drift time.Duration) *pb.Probe {
 	return &pb.Probe{
 		Checker: timeDriftCheckerID,
 		Detail:  fmt.Sprintf("time drift between %s and %s is %s", node1, node2, drift),

--- a/monitoring/timedrift.go
+++ b/monitoring/timedrift.go
@@ -326,7 +326,7 @@ func (c *timeDriftChecker) getAgentClient(ctx context.Context, node serf.Member)
 	}
 	c.mu.Unlock()
 
-	newConn, err := c.DialRPC(ctx, &node)
+	newConn, err := c.DialRPC(ctx, node.Addr.String())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/monitoring/timedrift.go
+++ b/monitoring/timedrift.go
@@ -19,17 +19,15 @@ package monitoring
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
-	"github.com/gravitational/satellite/agent"
 	"github.com/gravitational/satellite/agent/health"
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
+	"github.com/gravitational/satellite/lib/membership"
 	"github.com/gravitational/satellite/lib/rpc/client"
 
 	"github.com/gravitational/trace"
-	serf "github.com/hashicorp/serf/client"
 	"github.com/jonboulle/clockwork"
 	log "github.com/sirupsen/logrus"
 )
@@ -65,16 +63,10 @@ type timeDriftChecker struct {
 
 // TimeDriftCheckerConfig stores configuration for the time drift check.
 type TimeDriftCheckerConfig struct {
-	// CAFile is the path to the certificate authority file for Satellite agent.
-	CAFile string
-	// CertFile is the path to the Satellite agent client certificate file.
-	CertFile string
-	// KeyFile is the path to the Satellite agent private key file.
-	KeyFile string
-	// SerfClient is the client to the local serf agent.
-	SerfClient agent.SerfClient
-	// SerfMember is the local serf member.
-	SerfMember *serf.Member
+	// NodeName specifies the name of the node that is running the check.
+	NodeName string
+	// Cluster specifies the cluster membership interface.
+	membership.Cluster
 	// DialRPC is used to create Satellite RPC client.
 	DialRPC client.DialRPC
 	// Clock is used in tests to mock time.
@@ -83,23 +75,18 @@ type TimeDriftCheckerConfig struct {
 
 // CheckAndSetDefaults validates the config and sets default values.
 func (c *TimeDriftCheckerConfig) CheckAndSetDefaults() error {
-	if c.CAFile == "" {
-		return trace.BadParameter("agent CA certificate file can't be empty")
+	var errs []error
+	if c.NodeName == "" {
+		errs = append(errs, trace.BadParameter("NodeName must be provided"))
 	}
-	if c.CertFile == "" {
-		return trace.BadParameter("agent certificate file can't be empty")
-	}
-	if c.KeyFile == "" {
-		return trace.BadParameter("agent certificate key file can't be empty")
-	}
-	if c.SerfClient == nil {
-		return trace.BadParameter("local serf client can't be empty")
-	}
-	if c.SerfMember == nil {
-		return trace.BadParameter("local serf member can't be empty")
+	if c.Cluster == nil {
+		errs = append(errs, trace.BadParameter("Cluster must be provided"))
 	}
 	if c.DialRPC == nil {
-		c.DialRPC = client.DefaultDialRPC(c.CAFile, c.CertFile, c.KeyFile)
+		errs = append(errs, trace.BadParameter("DialRPC must be provided"))
+	}
+	if len(errs) > 0 {
+		return trace.NewAggregate(errs...)
 	}
 	if c.Clock == nil {
 		c.Clock = clockwork.NewRealClock()
@@ -131,7 +118,7 @@ func (c *timeDriftChecker) Check(ctx context.Context, r health.Reporter) {
 		return
 	}
 	if r.NumProbes() == 0 {
-		r.Add(c.successProbe())
+		r.Add(successProbe(c.NodeName))
 	}
 }
 
@@ -142,7 +129,7 @@ func (c *timeDriftChecker) check(ctx context.Context, r health.Reporter) (err er
 		return trace.Wrap(err)
 	}
 
-	nodesC := make(chan serf.Member, len(nodes))
+	nodesC := make(chan *pb.MemberStatus, len(nodes))
 	for _, node := range nodes {
 		nodesC <- node
 	}
@@ -165,7 +152,7 @@ func (c *timeDriftChecker) check(ctx context.Context, r health.Reporter) (err er
 
 				if isDriftHigh(drift) {
 					mutex.Lock()
-					r.Add(c.failureProbe(node, drift))
+					r.Add(failureProbe(c.NodeName, node.Name, drift))
 					mutex.Unlock()
 				}
 			}
@@ -204,7 +191,7 @@ func (c *timeDriftChecker) check(ctx context.Context, r health.Reporter) (err er
 //   mean the node time is falling behind.
 
 // * Compare abs(Drift) with the threshold.
-func (c *timeDriftChecker) getTimeDrift(ctx context.Context, node serf.Member) (time.Duration, error) {
+func (c *timeDriftChecker) getTimeDrift(ctx context.Context, node *pb.MemberStatus) (time.Duration, error) {
 	agentClient, err := c.getAgentClient(ctx, node)
 	if err != nil {
 		return 0, trace.Wrap(err)
@@ -248,30 +235,9 @@ func (c *timeDriftChecker) getTimeDrift(ctx context.Context, node serf.Member) (
 	return drift, nil
 }
 
-// successProbe constructs a probe that represents successful time drift check.
-func (c *timeDriftChecker) successProbe() *pb.Probe {
-	return &pb.Probe{
-		Checker: c.Name(),
-		Detail: fmt.Sprintf("time drift between %s and other nodes is within the allowed threshold of %s",
-			c.SerfMember.Addr, timeDriftThreshold),
-		Status: pb.Probe_Running,
-	}
-}
-
-// failureProbe constructs a probe that represents failed time drift check
-// against the specified node.
-func (c *timeDriftChecker) failureProbe(node serf.Member, drift time.Duration) *pb.Probe {
-	return &pb.Probe{
-		Checker: c.Name(),
-		Detail: fmt.Sprintf("time drift between %s and %s is higher than the allowed threshold of %s: %s",
-			c.SerfMember.Addr, node.Addr, timeDriftThreshold, drift),
-		Status: pb.Probe_Failed,
-	}
-}
-
 // nodesToCheck returns nodes to check time drift against.
-func (c *timeDriftChecker) nodesToCheck() (result []serf.Member, err error) {
-	nodes, err := c.SerfClient.Members()
+func (c *timeDriftChecker) nodesToCheck() (result []*pb.MemberStatus, err error) {
+	nodes, err := c.Cluster.Members()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -288,10 +254,10 @@ func (c *timeDriftChecker) nodesToCheck() (result []serf.Member, err error) {
 
 // removeExpiredClients closes client connections to nodes that have left the
 // cluster and deletes the entry from the cache.
-func (c *timeDriftChecker) removeExpiredClients(members []serf.Member) {
+func (c *timeDriftChecker) removeExpiredClients(members []*pb.MemberStatus) {
 	currentMembers := make(map[string]struct{})
 	for _, member := range members {
-		currentMembers[member.Addr.String()] = struct{}{}
+		currentMembers[member.Addr] = struct{}{}
 	}
 
 	c.mu.Lock()
@@ -312,21 +278,21 @@ func (c *timeDriftChecker) removeExpiredClients(members []serf.Member) {
 
 // shouldCheckNode returns true if the check should be run against specified
 // serf member.
-func (c *timeDriftChecker) shouldCheckNode(node serf.Member) bool {
-	return strings.ToLower(node.Status) == strings.ToLower(pb.MemberStatus_Alive.String()) &&
-		c.SerfMember.Addr.String() != node.Addr.String()
+func (c *timeDriftChecker) shouldCheckNode(node *pb.MemberStatus) bool {
+	return node.Status == pb.MemberStatus_Alive && c.NodeName != node.Name
 }
 
 // getAgentClient returns Satellite agent client for the provided node.
-func (c *timeDriftChecker) getAgentClient(ctx context.Context, node serf.Member) (client.Client, error) {
+func (c *timeDriftChecker) getAgentClient(ctx context.Context, node *pb.MemberStatus) (client.Client, error) {
+	addr := node.Addr
 	c.mu.Lock()
-	if conn, exists := c.clients[node.Addr.String()]; exists {
+	if conn, exists := c.clients[addr]; exists {
 		c.mu.Unlock()
 		return conn, nil
 	}
 	c.mu.Unlock()
 
-	newConn, err := c.DialRPC(ctx, node.Addr.String())
+	newConn, err := c.DialRPC(ctx, addr)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -335,19 +301,40 @@ func (c *timeDriftChecker) getAgentClient(ctx context.Context, node serf.Member)
 	defer c.mu.Unlock()
 
 	// Close newly created client connection if a new client was already cached while dialing.
-	if conn, exists := c.clients[node.Addr.String()]; exists {
+	if conn, exists := c.clients[addr]; exists {
 		if err := newConn.Close(); err != nil {
-			log.WithError(err).WithField("address", node.Addr.String()).Error("Failed to close client connection.")
+			log.WithError(err).WithField("address", addr).Error("Failed to close client connection.")
 		}
 		return conn, nil
 	}
 
 	// Cache and return new client connection.
-	c.clients[node.Addr.String()] = newConn
+	c.clients[addr] = newConn
 	return newConn, nil
 }
 
 // isDriftHigh returns true if the provided drift value is over the threshold.
 func isDriftHigh(drift time.Duration) bool {
 	return drift < 0 && -drift > timeDriftThreshold || drift > timeDriftThreshold
+}
+
+// successProbe constructs a probe that represents successful time drift check.
+func successProbe(node string) *pb.Probe {
+	return &pb.Probe{
+		Checker: timeDriftCheckerID,
+		Detail: fmt.Sprintf("time drift between %s and other nodes is within the allowed threshold of %s",
+			node, timeDriftThreshold),
+		Status: pb.Probe_Running,
+	}
+}
+
+// failureProbe constructs a probe that represents failed time drift check
+// between the specified nodes.
+func failureProbe(node1, node2 string, drift time.Duration) *pb.Probe {
+	return &pb.Probe{
+		Checker: timeDriftCheckerID,
+		Detail:  fmt.Sprintf("time drift between %s and %s is %s", node1, node2, drift),
+		Error:   fmt.Sprintf("time drift is higher than the allowed threshold of %s", timeDriftThreshold),
+		Status:  pb.Probe_Failed,
+	}
 }

--- a/monitoring/timedrift_test.go
+++ b/monitoring/timedrift_test.go
@@ -63,7 +63,7 @@ func (s *TimeDriftSuite) TestTimeDriftChecker(c *check.C) {
 				},
 			},
 			result: []*agentpb.Probe{
-				successProbe(node1),
+				successProbeTimeDrift(node1),
 			},
 		},
 		{
@@ -75,7 +75,7 @@ func (s *TimeDriftSuite) TestTimeDriftChecker(c *check.C) {
 				},
 			},
 			result: []*agentpb.Probe{
-				successProbe(node1),
+				successProbeTimeDrift(node1),
 			},
 		},
 		{
@@ -89,7 +89,7 @@ func (s *TimeDriftSuite) TestTimeDriftChecker(c *check.C) {
 			// Since we're using frozen time, latency will be 0 so
 			// time drift will be exactly the amount we specified.
 			result: []*agentpb.Probe{
-				failureProbe(node1, node3, driftOverThreshold),
+				failureProbeTimeDrift(node1, node3, driftOverThreshold),
 			},
 		},
 		{
@@ -101,7 +101,7 @@ func (s *TimeDriftSuite) TestTimeDriftChecker(c *check.C) {
 				},
 			},
 			result: []*agentpb.Probe{
-				failureProbe(node1, node2, -driftOverThreshold),
+				failureProbeTimeDrift(node1, node2, -driftOverThreshold),
 			},
 		},
 		{
@@ -113,8 +113,8 @@ func (s *TimeDriftSuite) TestTimeDriftChecker(c *check.C) {
 				},
 			},
 			result: []*agentpb.Probe{
-				failureProbe(node1, node2, -driftOverThreshold),
-				failureProbe(node1, node3, driftOverThreshold),
+				failureProbeTimeDrift(node1, node2, -driftOverThreshold),
+				failureProbeTimeDrift(node1, node3, driftOverThreshold),
 			},
 		},
 		{
@@ -127,7 +127,7 @@ func (s *TimeDriftSuite) TestTimeDriftChecker(c *check.C) {
 			},
 			slow: true,
 			result: []*agentpb.Probe{
-				successProbe(node1),
+				successProbeTimeDrift(node1),
 			},
 		},
 	}

--- a/monitoring/timedrift_test.go
+++ b/monitoring/timedrift_test.go
@@ -18,34 +18,28 @@ package monitoring
 
 import (
 	"context"
-	"net"
 	"sort"
 	"time"
 
-	"github.com/gravitational/satellite/agent"
 	"github.com/gravitational/satellite/agent/health"
 	"github.com/gravitational/satellite/agent/proto/agentpb"
+	pb "github.com/gravitational/satellite/agent/proto/agentpb"
 	debugpb "github.com/gravitational/satellite/agent/proto/debug"
+	"github.com/gravitational/satellite/lib/membership"
 	"github.com/gravitational/satellite/lib/rpc/client"
 
 	"github.com/gravitational/trace"
-	serf "github.com/hashicorp/serf/client"
 	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 	"gopkg.in/check.v1"
 )
 
 type TimeDriftSuite struct {
-	c     *timeDriftChecker
 	clock clockwork.Clock
 }
 
 var _ = check.Suite(&TimeDriftSuite{})
 
 func (s *TimeDriftSuite) SetUpSuite(c *check.C) {
-	s.c = &timeDriftChecker{TimeDriftCheckerConfig: TimeDriftCheckerConfig{
-		SerfMember: &node1,
-	}}
 	s.clock = clockwork.NewFakeClock()
 }
 
@@ -53,10 +47,8 @@ func (s *TimeDriftSuite) TestTimeDriftChecker(c *check.C) {
 	tests := []struct {
 		// comment is the test case description.
 		comment string
-		// nodes is a list of all serf members.
-		nodes []serf.Member
-		// times maps serf member to its drift value.
-		times map[string]time.Time
+		// cluster is the Satellite cluster.
+		cluster mockCluster
 		// result is the time drift check result.
 		result []*agentpb.Probe
 		// slow indicates the server should respond slowly
@@ -64,85 +56,91 @@ func (s *TimeDriftSuite) TestTimeDriftChecker(c *check.C) {
 	}{
 		{
 			comment: "Acceptable time drift",
-			nodes:   []serf.Member{node1, node2, node3},
-			times: map[string]time.Time{
-				node2.Name: s.clock.Now().Add(driftUnderThreshold()),
-				node3.Name: s.clock.Now().Add(driftUnderThreshold()),
+			cluster: mockCluster{
+				clients: map[string]*mockedTimeAgentClient{
+					node2: newMockedTimeAgentClient(node2, s.clock.Now().Add(driftUnderThreshold)),
+					node3: newMockedTimeAgentClient(node2, s.clock.Now().Add(driftUnderThreshold)),
+				},
 			},
 			result: []*agentpb.Probe{
-				s.c.successProbe(),
+				successProbe(node1),
 			},
 		},
 		{
 			comment: "Acceptable time drift, one node is lagging behind",
-			nodes:   []serf.Member{node1, node2, node3},
-			times: map[string]time.Time{
-				node2.Name: s.clock.Now().Add(driftUnderThreshold()),
-				node3.Name: s.clock.Now().Add(-driftUnderThreshold()),
+			cluster: mockCluster{
+				clients: map[string]*mockedTimeAgentClient{
+					node2: newMockedTimeAgentClient(node2, s.clock.Now().Add(driftUnderThreshold)),
+					node3: newMockedTimeAgentClient(node3, s.clock.Now().Add(-driftUnderThreshold)),
+				},
 			},
 			result: []*agentpb.Probe{
-				s.c.successProbe(),
+				successProbe(node1),
 			},
 		},
 		{
 			comment: "Time drift to node-3 exceeds threshold",
-			nodes:   []serf.Member{node1, node2, node3},
-			times: map[string]time.Time{
-				node2.Name: s.clock.Now().Add(driftUnderThreshold()),
-				node3.Name: s.clock.Now().Add(driftOverThreshold()),
+			cluster: mockCluster{
+				clients: map[string]*mockedTimeAgentClient{
+					node2: newMockedTimeAgentClient(node2, s.clock.Now().Add(driftUnderThreshold)),
+					node3: newMockedTimeAgentClient(node3, s.clock.Now().Add(driftOverThreshold)),
+				},
 			},
 			// Since we're using frozen time, latency will be 0 so
 			// time drift will be exactly the amount we specified.
 			result: []*agentpb.Probe{
-				s.c.failureProbe(node3, driftOverThreshold()),
+				failureProbe(node1, node3, driftOverThreshold),
 			},
 		},
 		{
 			comment: "Time drift to node-2 exceeds threshold",
-			nodes:   []serf.Member{node1, node2, node3},
-			times: map[string]time.Time{
-				node2.Name: s.clock.Now().Add(-driftOverThreshold()),
-				node3.Name: s.clock.Now().Add(driftUnderThreshold()),
+			cluster: mockCluster{
+				clients: map[string]*mockedTimeAgentClient{
+					node2: newMockedTimeAgentClient(node2, s.clock.Now().Add(-driftOverThreshold)),
+					node3: newMockedTimeAgentClient(node3, s.clock.Now().Add(driftUnderThreshold)),
+				},
 			},
 			result: []*agentpb.Probe{
-				s.c.failureProbe(node2, -driftOverThreshold()),
+				failureProbe(node1, node2, -driftOverThreshold),
 			},
 		},
 		{
 			comment: "Time drift to both nodes exceeds threshold",
-			nodes:   []serf.Member{node1, node2, node3},
-			times: map[string]time.Time{
-				node2.Name: s.clock.Now().Add(-driftOverThreshold()),
-				node3.Name: s.clock.Now().Add(driftOverThreshold()),
+			cluster: mockCluster{
+				clients: map[string]*mockedTimeAgentClient{
+					node2: newMockedTimeAgentClient(node2, s.clock.Now().Add(-driftOverThreshold)),
+					node3: newMockedTimeAgentClient(node3, s.clock.Now().Add(driftOverThreshold)),
+				},
 			},
 			result: []*agentpb.Probe{
-				s.c.failureProbe(node2, -driftOverThreshold()),
-				s.c.failureProbe(node3, driftOverThreshold()),
+				failureProbe(node1, node2, -driftOverThreshold),
+				failureProbe(node1, node3, driftOverThreshold),
 			},
 		},
 		{
 			comment: "Time drift takes too long to respond silently discarding results",
-			slow:    true,
-			nodes:   []serf.Member{node1, node2, node3},
-			times: map[string]time.Time{
-				node2.Name: s.clock.Now().Add(-driftOverThreshold()),
-				node3.Name: s.clock.Now().Add(driftOverThreshold()),
+			cluster: mockCluster{
+				clients: map[string]*mockedTimeAgentClient{
+					node2: newMockedTimeAgentClient(node2, s.clock.Now().Add(-driftOverThreshold)),
+					node3: newMockedTimeAgentClient(node3, s.clock.Now().Add(driftOverThreshold)),
+				},
 			},
+			slow: true,
 			result: []*agentpb.Probe{
-				s.c.successProbe(),
+				successProbe(node1),
 			},
 		},
 	}
 	for _, test := range tests {
-		checker := &timeDriftChecker{
-			TimeDriftCheckerConfig: TimeDriftCheckerConfig{
-				SerfClient: agent.NewMockSerfClient(test.nodes, nil),
-				SerfMember: &node1,
-				Clock:      s.clock,
-			},
-			FieldLogger: logrus.WithField(trace.Component, "test"),
-			clients:     newClientsCache(test.times),
-		}
+
+		checker, err := NewTimeDriftChecker(TimeDriftCheckerConfig{
+			NodeName: node1,
+			Cluster:  test.cluster,
+			DialRPC:  test.cluster.dial,
+			Clock:    s.clock,
+		})
+		c.Assert(err, check.IsNil, check.Commentf(test.comment))
+
 		var probes health.Probes
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -157,22 +155,46 @@ func (s *TimeDriftSuite) TestTimeDriftChecker(c *check.C) {
 	}
 }
 
-// driftOverThreshold returns time drift value that exceeds configured threshold.
-func driftOverThreshold() time.Duration {
-	return timeDriftThreshold * 2
+type mockCluster struct {
+	membership.Cluster
+	clients map[string]*mockedTimeAgentClient
 }
 
-// driftUnderThreshold returns time drift value that is within configured threshold.
-func driftUnderThreshold() time.Duration {
-	return timeDriftThreshold / 2
+func (r mockCluster) Members() ([]*pb.MemberStatus, error) {
+	members := make([]*pb.MemberStatus, 0, len(r.clients))
+	for _, client := range r.clients {
+		members = append(members, memberFromMockClient(client))
+	}
+	return members, nil
+}
+
+func (r mockCluster) dial(_ context.Context, name string) (client.Client, error) {
+	client, exists := r.clients[name]
+	if !exists {
+		return nil, trace.NotFound("member %s does not exist in this cluster", name)
+	}
+	return client, nil
+}
+
+// memberFromMockClient constructs a new ClusterMember from the provided client.
+func memberFromMockClient(client *mockedTimeAgentClient) *pb.MemberStatus {
+	return &pb.MemberStatus{
+		Name:   client.name,
+		Addr:   client.name, // mock dial function will use name to dial node
+		Status: pb.MemberStatus_Alive,
+	}
 }
 
 type mockedTimeAgentClient struct {
 	time time.Time
+	name string
 }
 
-func newMockedTimeAgentClient(time time.Time) *mockedTimeAgentClient {
-	return &mockedTimeAgentClient{time: time}
+func newMockedTimeAgentClient(name string, time time.Time) *mockedTimeAgentClient {
+	return &mockedTimeAgentClient{
+		name: name,
+		time: time,
+	}
 }
 
 func (a *mockedTimeAgentClient) Status(ctx context.Context) (*agentpb.SystemStatus, error) {
@@ -222,33 +244,13 @@ func (a *mockedTimeAgentClient) Close() error {
 	return nil
 }
 
-func newClientsCache(times map[string]time.Time) map[string]client.Client {
-	clients := make(map[string]client.Client)
-	for nodeName, nodeTime := range times {
-		clients[nodes[nodeName].Addr.String()] = newMockedTimeAgentClient(nodeTime)
-	}
-	return clients
-}
+const (
+	// Test nodes
+	node1 = "node-1"
+	node2 = "node-2"
+	node3 = "node-3"
 
-var (
-	node1 serf.Member = serf.Member{
-		Name:   "node-1",
-		Status: agentpb.MemberStatus_Alive.String(),
-		Addr:   net.IPv4(192, 168, 0, 1),
-	}
-	node2 serf.Member = serf.Member{
-		Name:   "node-2",
-		Status: agentpb.MemberStatus_Alive.String(),
-		Addr:   net.IPv4(192, 168, 0, 2),
-	}
-	node3 serf.Member = serf.Member{
-		Name:   "node-3",
-		Status: agentpb.MemberStatus_Alive.String(),
-		Addr:   net.IPv4(192, 168, 0, 3),
-	}
-	nodes map[string]serf.Member = map[string]serf.Member{
-		node1.Name: node1,
-		node2.Name: node2,
-		node3.Name: node3,
-	}
+	// Arbitrary values over and under the default time drift threshold
+	driftOverThreshold  = timeDriftThreshold * 2
+	driftUnderThreshold = timeDriftThreshold / 2
 )

--- a/monitoring/timedrift_test.go
+++ b/monitoring/timedrift_test.go
@@ -47,7 +47,7 @@ func (s *TimeDriftSuite) TestTimeDriftChecker(c *check.C) {
 	tests := []struct {
 		// comment is the test case description.
 		comment string
-		// cluster is the Satellite cluster.
+		// cluster is a mock cluster interface.
 		cluster mockCluster
 		// result is the time drift check result.
 		result []*agentpb.Probe


### PR DESCRIPTION
## Description
This PR updates the cluster membership interface. Cluster interface is no longer intended to manage the cluster membership, its only purpose is to query membership status. `IsMember` and `Join` methods have been removed from the agent interface. Management of cluster membership should be handled outside of satellite and in planet or gravity. 

Updates the time drift checker and latency checker to now interface with the cluster membership interface.

This is an intermediate PR for removing Serf dependency from satellite. Serf cluster implementation will be replaced with an implementation using Kubernetes api.