### PR TITLE
OpenEBS enhancements

### DIFF
--- a/cmd/agent/local.go
+++ b/cmd/agent/local.go
@@ -24,7 +24,7 @@ import (
 )
 
 func localChecks() error {
-	ch := monitoring.BasicCheckers()
+	ch := monitoring.BasicCheckers(monitoring.DefaultProcessesToCheck)
 	var r health.Probes
 
 	ch.Check(context.TODO(), &r)

--- a/monitoring/defaults_linux.go
+++ b/monitoring/defaults_linux.go
@@ -31,8 +31,6 @@ var (
 		"kube-controller-manager",
 		"kube-proxy",
 		"kubelet",
-		"planet",
-		"teleport",
 	}
 )
 

--- a/monitoring/iscsi.go
+++ b/monitoring/iscsi.go
@@ -71,7 +71,9 @@ func (c iscsiChecker) Check(ctx context.Context, reporter health.Reporter) {
 				reporter.Add(&pb.Probe{
 					Checker: iscsiCheckerID,
 					Detail: fmt.Sprintf("Found conflicting systemd service: %v. "+
-						"Please stop, disable and mask this service and try again.", unit.Name),
+						"If this service is present on the host it will interfere "+
+						"with OpenEBS enabled applications running in Gravity."+
+						"Please stop and mask this service and try again.", unit.Name),
 					Status: pb.Probe_Failed,
 				})
 				probeFailed = true

--- a/monitoring/iscsi.go
+++ b/monitoring/iscsi.go
@@ -66,7 +66,8 @@ func (c iscsiChecker) Check(ctx context.Context, reporter health.Reporter) {
 
 	probeFailed := false
 	for _, unit := range units {
-		if unit.Name == "iscsid.service" || unit.Name == "iscsid.socket" {
+		switch unit.Name {
+		case "iscisid.service", "iscsid.socket":
 			if unit.ActiveState == "active" || unit.LoadState != loadStateMasked {
 				reporter.Add(&pb.Probe{
 					Checker: iscsiCheckerID,

--- a/monitoring/iscsi.go
+++ b/monitoring/iscsi.go
@@ -79,6 +79,7 @@ func (c iscsiChecker) Check(ctx context.Context, reporter health.Reporter) {
 	c.CheckISCSIUnits(units, reporter)
 }
 
+// CheckISCSIUnits verifies that the systemd units are in the expected state.
 func (c iscsiChecker) CheckISCSIUnits(units []dbus.UnitStatus, reporter health.Reporter) {
 	for _, unit := range units {
 		switch unit.Name {

--- a/monitoring/iscsi.go
+++ b/monitoring/iscsi.go
@@ -35,6 +35,8 @@ const (
 	ISCSIDSocket = "iscsid.socket"
 )
 
+// FormatISCSIError is used to format the error messages
+// that is shown to the user when the iscsi probe fails.
 type FormatISCSIError func(unitName string) string
 
 // NewISCSIChecker verifies that the iscsid service is not running on the host.

--- a/monitoring/iscsi.go
+++ b/monitoring/iscsi.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gravitational/satellite/agent/health"
+	pb "github.com/gravitational/satellite/agent/proto/agentpb"
+
+	"github.com/coreos/go-systemd/v22/dbus"
+	"github.com/gravitational/trace"
+)
+
+const (
+	iscsiCheckerID = "iscsi"
+)
+
+// NewISCSIChecker returns a new checker, that checks that the iscsid is not running on the host when
+// OpenEBS is enabled in the deployment manifest. This is needed because if iscsid is running on the host it
+// makes the iscsid in planet to fail.
+func NewISCSIChecker() health.Checker {
+	return &iscsiChecker{}
+}
+
+type iscsiChecker struct{}
+
+// Name returns the name of this checker
+// Implements health.Checker
+func (c iscsiChecker) Name() string {
+	return iscsiCheckerID
+}
+
+// Check will check the systemd unit data coming from dbus to verify that
+// there are no iscsid services present on the host.
+func (c iscsiChecker) Check(ctx context.Context, reporter health.Reporter) {
+	conn, err := dbus.New()
+	if err != nil {
+		reason := "failed to connect to dbus"
+		reporter.Add(NewProbeFromErr(c.Name(), reason, trace.Wrap(err)))
+	}
+	defer conn.Close()
+
+	units, err := conn.ListUnits()
+	if err != nil {
+		reason := "failed to query systemd units"
+		reporter.Add(NewProbeFromErr(c.Name(), reason, trace.Wrap(err)))
+	}
+
+	probeFailed := false
+	for _, unit := range units {
+		if unit.Name == "iscsid.service" || unit.Name == "iscsid.socket" {
+			if unit.ActiveState == "active" || unit.LoadState != loadStateMasked {
+				reporter.Add(&pb.Probe{
+					Checker: iscsiCheckerID,
+					Detail: fmt.Sprintf("Found conflicting systemd service: %v. "+
+						"Please stop, disable and mask this service and try again.", unit.Name),
+					Status: pb.Probe_Failed,
+				})
+				probeFailed = true
+			}
+		}
+	}
+
+	if !probeFailed {
+		reporter.Add(NewSuccessProbe(c.Name()))
+	}
+}

--- a/monitoring/iscsi.go
+++ b/monitoring/iscsi.go
@@ -68,7 +68,7 @@ func (c iscsiChecker) Check(ctx context.Context, reporter health.Reporter) {
 	for _, unit := range units {
 		switch unit.Name {
 		case "iscisid.service", "iscsid.socket":
-			if unit.ActiveState == "active" || unit.LoadState != loadStateMasked {
+			if unit.ActiveState == activeStateActive || unit.LoadState != loadStateMasked {
 				reporter.Add(&pb.Probe{
 					Checker: iscsiCheckerID,
 					Detail: fmt.Sprintf("Found conflicting systemd service: %v. "+

--- a/monitoring/iscsi.go
+++ b/monitoring/iscsi.go
@@ -53,13 +53,15 @@ func (c iscsiChecker) Check(ctx context.Context, reporter health.Reporter) {
 	if err != nil {
 		reason := "failed to connect to dbus"
 		reporter.Add(NewProbeFromErr(c.Name(), reason, trace.Wrap(err)))
+		return
 	}
 	defer conn.Close()
 
 	units, err := conn.ListUnits()
 	if err != nil {
-		reason := "failed to query systemd units"
+		reason := "failed to list systemd units via dbus"
 		reporter.Add(NewProbeFromErr(c.Name(), reason, trace.Wrap(err)))
+		return
 	}
 
 	probeFailed := false

--- a/monitoring/iscsi.go
+++ b/monitoring/iscsi.go
@@ -30,9 +30,13 @@ import (
 const (
 	iscsiCheckerID = "iscsi"
 
+	// ISCSIDService is the name of the iscsid systemd service unit.
 	ISCSIDService = "iscsid.service"
-	ISCSIDSocket  = "iscsid.socket"
+	// ISCSIDSocket is the name of the iscsid systemd socket unit.
+	ISCSIDSocket = "iscsid.socket"
 
+	// FailedProbeMessage is the error message that gets displayed to the user
+	// when the validation fails.
 	FailedProbeMessage = "Found conflicting systemd service: %v. " +
 		"If this service is present on the host it will interfere " +
 		"with OpenEBS enabled applications running in Gravity." +
@@ -76,7 +80,6 @@ func (c iscsiChecker) Check(ctx context.Context, reporter health.Reporter) {
 }
 
 func (c iscsiChecker) CheckISCSIUnits(units []dbus.UnitStatus, reporter health.Reporter) {
-	probeFailed := false
 	for _, unit := range units {
 		switch unit.Name {
 		case ISCSIDService, ISCSIDSocket:
@@ -86,12 +89,11 @@ func (c iscsiChecker) CheckISCSIUnits(units []dbus.UnitStatus, reporter health.R
 					Detail:  fmt.Sprintf(FailedProbeMessage, unit.Name),
 					Status:  pb.Probe_Failed,
 				})
-				probeFailed = true
 			}
 		}
 	}
 
-	if !probeFailed {
+	if reporter.NumProbes() == 0 {
 		reporter.Add(NewSuccessProbe(c.Name()))
 	}
 }

--- a/monitoring/iscsi_test.go
+++ b/monitoring/iscsi_test.go
@@ -18,12 +18,12 @@ package monitoring
 
 import (
 	"fmt"
-	"github.com/coreos/go-systemd/v22/dbus"
 
 	"github.com/gravitational/satellite/agent/health"
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
 	"github.com/gravitational/satellite/lib/test"
 
+	"github.com/coreos/go-systemd/v22/dbus"
 	. "gopkg.in/check.v1"
 )
 

--- a/monitoring/iscsi_test.go
+++ b/monitoring/iscsi_test.go
@@ -31,6 +31,9 @@ const (
 	inactiveAndMasked = "ActiveState is inactive and LoadState is masked."
 	activeAndLoaded   = "ActiveState is active and LoadState is loaded."
 	inactiveAndLoaded = "ActiveState is inactive and LoadState is loaded."
+
+	failedProbeMessage = "Found conflicting systemd service: %v. " +
+		"Please stop and mask this service and try again."
 )
 
 type ISCSISuite struct{}
@@ -50,7 +53,7 @@ func (s *ISCSISuite) TestISCSI(c *C) {
 			unitStatus: []dbus.UnitStatus{{Name: ISCSIDService, ActiveState: activeStateActive, LoadState: loadStateLoaded}},
 			probe: &pb.Probe{
 				Checker: iscsiCheckerID,
-				Detail:  fmt.Sprintf(FailedProbeMessage, ISCSIDService),
+				Detail:  fmt.Sprintf(failedProbeMessage, ISCSIDService),
 				Status:  pb.Probe_Failed,
 			},
 		},
@@ -59,7 +62,7 @@ func (s *ISCSISuite) TestISCSI(c *C) {
 			unitStatus: []dbus.UnitStatus{{Name: ISCSIDService, ActiveState: activeStateInactive, LoadState: loadStateLoaded}},
 			probe: &pb.Probe{
 				Checker: iscsiCheckerID,
-				Detail:  fmt.Sprintf(FailedProbeMessage, ISCSIDService),
+				Detail:  fmt.Sprintf(failedProbeMessage, ISCSIDService),
 				Status:  pb.Probe_Failed,
 			},
 		},
@@ -68,7 +71,7 @@ func (s *ISCSISuite) TestISCSI(c *C) {
 			unitStatus: []dbus.UnitStatus{{Name: ISCSIDSocket, ActiveState: activeStateActive, LoadState: loadStateLoaded}},
 			probe: &pb.Probe{
 				Checker: iscsiCheckerID,
-				Detail:  fmt.Sprintf(FailedProbeMessage, ISCSIDSocket),
+				Detail:  fmt.Sprintf(failedProbeMessage, ISCSIDSocket),
 				Status:  pb.Probe_Failed,
 			},
 		},
@@ -77,7 +80,7 @@ func (s *ISCSISuite) TestISCSI(c *C) {
 			unitStatus: []dbus.UnitStatus{{Name: ISCSIDSocket, ActiveState: activeStateInactive, LoadState: loadStateLoaded}},
 			probe: &pb.Probe{
 				Checker: iscsiCheckerID,
-				Detail:  fmt.Sprintf(FailedProbeMessage, ISCSIDSocket),
+				Detail:  fmt.Sprintf(failedProbeMessage, ISCSIDSocket),
 				Status:  pb.Probe_Failed,
 			},
 		},
@@ -102,7 +105,7 @@ func (s *ISCSISuite) TestISCSI(c *C) {
 	}
 
 	for _, testCase := range testCases {
-		checker := iscsiChecker{}
+		checker := iscsiChecker{FailedProbeMessage: failedProbeMessage}
 		var reporter health.Probes
 		checker.CheckISCSIUnits(testCase.unitStatus, &reporter)
 		c.Assert(reporter.GetProbes(), test.DeepCompare, []*pb.Probe{testCase.probe}, testCase.comment)

--- a/monitoring/iscsi_test.go
+++ b/monitoring/iscsi_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"fmt"
+	"github.com/coreos/go-systemd/v22/dbus"
+
+	"github.com/gravitational/satellite/agent/health"
+	pb "github.com/gravitational/satellite/agent/proto/agentpb"
+	"github.com/gravitational/satellite/lib/test"
+
+	. "gopkg.in/check.v1"
+)
+
+const (
+	ActiveAndMasked   = "ActiveState is inactive and LoadState is masked."
+	ActiveAndLoaded   = "ActiveState is active and LoadState is loaded."
+	InactiveAndLoaded = "ActiveState is inactive and LoadState is loaded."
+)
+
+type ISCSISuite struct{}
+
+var _ = Suite(&ISCSISuite{})
+
+// TestISCSI verifies that the checker correctly identifies
+// if there are running or enabled iscsi related systemd services.
+func (s *ISCSISuite) TestISCSI(c *C) {
+	var testCases = []struct {
+		comment    CommentInterface
+		unitStatus []dbus.UnitStatus
+		probe      *pb.Probe
+	}{
+		{
+			comment:    Commentf(ActiveAndLoaded),
+			unitStatus: []dbus.UnitStatus{{Name: ISCSIDService, ActiveState: activeStateActive, LoadState: loadStateLoaded}},
+			probe: &pb.Probe{
+				Checker: iscsiCheckerID,
+				Detail:  fmt.Sprintf(FailedProbeMessage, ISCSIDService),
+				Status:  pb.Probe_Failed,
+			},
+		},
+		{
+			comment:    Commentf(InactiveAndLoaded),
+			unitStatus: []dbus.UnitStatus{{Name: ISCSIDService, ActiveState: activeStateInactive, LoadState: loadStateLoaded}},
+			probe: &pb.Probe{
+				Checker: iscsiCheckerID,
+				Detail:  fmt.Sprintf(FailedProbeMessage, ISCSIDService),
+				Status:  pb.Probe_Failed,
+			},
+		},
+		{
+			comment:    Commentf(ActiveAndLoaded),
+			unitStatus: []dbus.UnitStatus{{Name: ISCSIDSocket, ActiveState: activeStateActive, LoadState: loadStateLoaded}},
+			probe: &pb.Probe{
+				Checker: iscsiCheckerID,
+				Detail:  fmt.Sprintf(FailedProbeMessage, ISCSIDSocket),
+				Status:  pb.Probe_Failed,
+			},
+		},
+		{
+			comment:    Commentf(InactiveAndLoaded),
+			unitStatus: []dbus.UnitStatus{{Name: ISCSIDSocket, ActiveState: activeStateInactive, LoadState: loadStateLoaded}},
+			probe: &pb.Probe{
+				Checker: iscsiCheckerID,
+				Detail:  fmt.Sprintf(FailedProbeMessage, ISCSIDSocket),
+				Status:  pb.Probe_Failed,
+			},
+		},
+		{
+			comment:    Commentf(ActiveAndMasked),
+			unitStatus: []dbus.UnitStatus{{Name: ISCSIDService, ActiveState: activeStateInactive, LoadState: loadStateMasked}},
+			probe: &pb.Probe{
+				Checker: iscsiCheckerID,
+				Detail:  "",
+				Status:  pb.Probe_Running,
+			},
+		},
+		{
+			comment:    Commentf(ActiveAndMasked),
+			unitStatus: []dbus.UnitStatus{{Name: ISCSIDSocket, ActiveState: activeStateInactive, LoadState: loadStateMasked}},
+			probe: &pb.Probe{
+				Checker: iscsiCheckerID,
+				Detail:  "",
+				Status:  pb.Probe_Running,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		checker := iscsiChecker{}
+		var reporter health.Probes
+		checker.CheckISCSIUnits(testCase.unitStatus, &reporter)
+		c.Assert(reporter.GetProbes(), test.DeepCompare, []*pb.Probe{testCase.probe}, testCase.comment)
+	}
+}

--- a/monitoring/iscsi_test.go
+++ b/monitoring/iscsi_test.go
@@ -28,9 +28,12 @@ import (
 )
 
 const (
-	inactiveAndMasked = "ActiveState is inactive and LoadState is masked."
-	activeAndLoaded   = "ActiveState is active and LoadState is loaded."
-	inactiveAndLoaded = "ActiveState is inactive and LoadState is loaded."
+	inactiveAndMaskedService = "Service unit ActiveState is inactive and LoadState is masked."
+	inactiveAndMaskedSocket  = "Socket activate unit ActiveState is inactive and LoadState is masked."
+	activeAndLoadedService   = "Service unit ActiveState is active and LoadState is loaded."
+	activeAndLoadedSocket    = "Socket activated unit ActiveState is active and LoadState is loaded."
+	inactiveAndLoadedService = "Service unit ActiveState is inactive and LoadState is loaded."
+	inactiveAndLoadedSocket  = "Socket activated unit ActiveState is inactive and LoadState is loaded."
 
 	failedProbeMessage = "Found conflicting systemd service: %v. " +
 		"Please stop and mask this service and try again."
@@ -55,7 +58,7 @@ func (s *ISCSISuite) TestISCSI(c *C) {
 		probe      *pb.Probe
 	}{
 		{
-			comment:    Commentf(activeAndLoaded),
+			comment:    Commentf(activeAndLoadedService),
 			unitStatus: []dbus.UnitStatus{{Name: ISCSIDService, ActiveState: activeStateActive, LoadState: loadStateLoaded}},
 			probe: &pb.Probe{
 				Checker: iscsiCheckerID,
@@ -64,7 +67,7 @@ func (s *ISCSISuite) TestISCSI(c *C) {
 			},
 		},
 		{
-			comment:    Commentf(inactiveAndLoaded),
+			comment:    Commentf(inactiveAndLoadedService),
 			unitStatus: []dbus.UnitStatus{{Name: ISCSIDService, ActiveState: activeStateInactive, LoadState: loadStateLoaded}},
 			probe: &pb.Probe{
 				Checker: iscsiCheckerID,
@@ -73,7 +76,7 @@ func (s *ISCSISuite) TestISCSI(c *C) {
 			},
 		},
 		{
-			comment:    Commentf(activeAndLoaded),
+			comment:    Commentf(activeAndLoadedSocket),
 			unitStatus: []dbus.UnitStatus{{Name: ISCSIDSocket, ActiveState: activeStateActive, LoadState: loadStateLoaded}},
 			probe: &pb.Probe{
 				Checker: iscsiCheckerID,
@@ -82,7 +85,7 @@ func (s *ISCSISuite) TestISCSI(c *C) {
 			},
 		},
 		{
-			comment:    Commentf(inactiveAndLoaded),
+			comment:    Commentf(inactiveAndLoadedSocket),
 			unitStatus: []dbus.UnitStatus{{Name: ISCSIDSocket, ActiveState: activeStateInactive, LoadState: loadStateLoaded}},
 			probe: &pb.Probe{
 				Checker: iscsiCheckerID,
@@ -91,7 +94,7 @@ func (s *ISCSISuite) TestISCSI(c *C) {
 			},
 		},
 		{
-			comment:    Commentf(inactiveAndMasked),
+			comment:    Commentf(inactiveAndMaskedService),
 			unitStatus: []dbus.UnitStatus{{Name: ISCSIDService, ActiveState: activeStateInactive, LoadState: loadStateMasked}},
 			probe: &pb.Probe{
 				Checker: iscsiCheckerID,
@@ -100,7 +103,7 @@ func (s *ISCSISuite) TestISCSI(c *C) {
 			},
 		},
 		{
-			comment:    Commentf(inactiveAndMasked),
+			comment:    Commentf(inactiveAndMaskedSocket),
 			unitStatus: []dbus.UnitStatus{{Name: ISCSIDSocket, ActiveState: activeStateInactive, LoadState: loadStateMasked}},
 			probe: &pb.Probe{
 				Checker: iscsiCheckerID,

--- a/monitoring/iscsi_test.go
+++ b/monitoring/iscsi_test.go
@@ -28,9 +28,9 @@ import (
 )
 
 const (
-	ActiveAndMasked   = "ActiveState is inactive and LoadState is masked."
-	ActiveAndLoaded   = "ActiveState is active and LoadState is loaded."
-	InactiveAndLoaded = "ActiveState is inactive and LoadState is loaded."
+	inactiveAndMasked = "ActiveState is inactive and LoadState is masked."
+	activeAndLoaded   = "ActiveState is active and LoadState is loaded."
+	inactiveAndLoaded = "ActiveState is inactive and LoadState is loaded."
 )
 
 type ISCSISuite struct{}
@@ -46,7 +46,7 @@ func (s *ISCSISuite) TestISCSI(c *C) {
 		probe      *pb.Probe
 	}{
 		{
-			comment:    Commentf(ActiveAndLoaded),
+			comment:    Commentf(activeAndLoaded),
 			unitStatus: []dbus.UnitStatus{{Name: ISCSIDService, ActiveState: activeStateActive, LoadState: loadStateLoaded}},
 			probe: &pb.Probe{
 				Checker: iscsiCheckerID,
@@ -55,7 +55,7 @@ func (s *ISCSISuite) TestISCSI(c *C) {
 			},
 		},
 		{
-			comment:    Commentf(InactiveAndLoaded),
+			comment:    Commentf(inactiveAndLoaded),
 			unitStatus: []dbus.UnitStatus{{Name: ISCSIDService, ActiveState: activeStateInactive, LoadState: loadStateLoaded}},
 			probe: &pb.Probe{
 				Checker: iscsiCheckerID,
@@ -64,7 +64,7 @@ func (s *ISCSISuite) TestISCSI(c *C) {
 			},
 		},
 		{
-			comment:    Commentf(ActiveAndLoaded),
+			comment:    Commentf(activeAndLoaded),
 			unitStatus: []dbus.UnitStatus{{Name: ISCSIDSocket, ActiveState: activeStateActive, LoadState: loadStateLoaded}},
 			probe: &pb.Probe{
 				Checker: iscsiCheckerID,
@@ -73,7 +73,7 @@ func (s *ISCSISuite) TestISCSI(c *C) {
 			},
 		},
 		{
-			comment:    Commentf(InactiveAndLoaded),
+			comment:    Commentf(inactiveAndLoaded),
 			unitStatus: []dbus.UnitStatus{{Name: ISCSIDSocket, ActiveState: activeStateInactive, LoadState: loadStateLoaded}},
 			probe: &pb.Probe{
 				Checker: iscsiCheckerID,
@@ -82,7 +82,7 @@ func (s *ISCSISuite) TestISCSI(c *C) {
 			},
 		},
 		{
-			comment:    Commentf(ActiveAndMasked),
+			comment:    Commentf(inactiveAndMasked),
 			unitStatus: []dbus.UnitStatus{{Name: ISCSIDService, ActiveState: activeStateInactive, LoadState: loadStateMasked}},
 			probe: &pb.Probe{
 				Checker: iscsiCheckerID,
@@ -91,7 +91,7 @@ func (s *ISCSISuite) TestISCSI(c *C) {
 			},
 		},
 		{
-			comment:    Commentf(ActiveAndMasked),
+			comment:    Commentf(inactiveAndMasked),
 			unitStatus: []dbus.UnitStatus{{Name: ISCSIDSocket, ActiveState: activeStateInactive, LoadState: loadStateMasked}},
 			probe: &pb.Probe{
 				Checker: iscsiCheckerID,

--- a/monitoring/iscsi_test.go
+++ b/monitoring/iscsi_test.go
@@ -36,6 +36,12 @@ const (
 		"Please stop and mask this service and try again."
 )
 
+var (
+	fmtISCSICheckFailedMsg = func(unitName string) string {
+		return fmt.Sprintf(failedProbeMessage, unitName)
+	}
+)
+
 type ISCSISuite struct{}
 
 var _ = Suite(&ISCSISuite{})
@@ -105,7 +111,7 @@ func (s *ISCSISuite) TestISCSI(c *C) {
 	}
 
 	for _, testCase := range testCases {
-		checker := iscsiChecker{FailedProbeMessage: failedProbeMessage}
+		checker := iscsiChecker{FailedProbeMsgFmt: fmtISCSICheckFailedMsg}
 		var reporter health.Probes
 		checker.CheckISCSIUnits(testCase.unitStatus, &reporter)
 		c.Assert(reporter.GetProbes(), test.DeepCompare, []*pb.Probe{testCase.probe}, testCase.comment)

--- a/monitoring/systemd.go
+++ b/monitoring/systemd.go
@@ -159,13 +159,11 @@ const (
 	loadStateNotFound           = "not-found"
 )
 
-type activeState string
-
 const (
-	activeStateActive       activeState = "active"
-	activeStateReloading                = "reloading"
-	activeStateInactive                 = "inactive"
-	activeStateFailed                   = "failed"
-	activeStateActivating               = "activating"
-	activeStateDeactivating             = "deactivating"
+	activeStateActive       = "active"
+	activeStateReloading    = "reloading"
+	activeStateInactive     = "inactive"
+	activeStateFailed       = "failed"
+	activeStateActivating   = "activating"
+	activeStateDeactivating = "deactivating"
 )

--- a/monitoring/systemd.go
+++ b/monitoring/systemd.go
@@ -150,13 +150,11 @@ type serviceStatus struct {
 
 var systemStatusCmd = []string{"/bin/systemctl", "is-system-running"}
 
-type loadState string
-
 const (
-	loadStateLoaded   loadState = "loaded"
-	loadStateError              = "error"
-	loadStateMasked             = "masked"
-	loadStateNotFound           = "not-found"
+	loadStateLoaded   = "loaded"
+	loadStateError    = "error"
+	loadStateMasked   = "masked"
+	loadStateNotFound = "not-found"
 )
 
 const (


### PR DESCRIPTION
This PR provides the following OpenEBS related enhancements:

* A new checker, that checks that the iscsid is not running on the host when
 OpenEBS is enabled in the Gravity's app deployment manifest. This is needed because if iscsid is running on the host it
 makes the iscsid in Gravity's Planet to fail. 

Also this helps to avoid possible issues with version mismatch between iscsid on the host and what is expected by OpenEBS in the deployment. If the versions don't match the app will not work when deployed on a host with incompatible iscsid. Installing iscsid in Gravity's Planet avoids the version mismatch. 