### PR TITLE
[7.0] Remove CONFIG_NF_NAT_IPV4 check

### DIFF
--- a/monitoring/defaults_linux.go
+++ b/monitoring/defaults_linux.go
@@ -113,12 +113,6 @@ func DefaultBootConfigParams() health.Checker {
 		BootConfigParam{Name: "CONFIG_VETH"},
 		BootConfigParam{Name: "CONFIG_BRIDGE"},
 		BootConfigParam{Name: "CONFIG_BRIDGE_NETFILTER"},
-		BootConfigParam{
-			// https://cateee.net/lkddb/web-lkddb/NF_NAT_IPV4.html
-			// CONFIG_NF_NAT_IPV4 has been removed as of kernel 5.1
-			Name:             "CONFIG_NF_NAT_IPV4",
-			KernelConstraint: KernelVersionLessThan(KernelVersion{Release: 5, Major: 1}),
-		},
 		BootConfigParam{Name: "CONFIG_IP_NF_FILTER"},
 		BootConfigParam{Name: "CONFIG_IP_NF_TARGET_MASQUERADE"},
 		BootConfigParam{Name: "CONFIG_NETFILTER_XT_MATCH_ADDRTYPE"},


### PR DESCRIPTION
## Description
This is the 7.0 Backport of https://github.com/gravitational/satellite/pull/285.

Removes CONFIG_NF_NAT_IPV4 check. The config has been removed in newer kernel versions. In order to avoid additional code maintenance in the future, the check has been removed. Newer versions of Gravity running on an older kernel may fail silently if the config is not found.

## Linked tickets and PRs

Contributes to gravitational/gravity#2331