### PR TITLE
[6.1.x] Remove CONFIG_NF_NAT_IPV4 check

### DIFF
--- a/monitoring/defaults_linux.go
+++ b/monitoring/defaults_linux.go
@@ -114,12 +114,6 @@ func DefaultBootConfigParams() health.Checker {
 		BootConfigParam{Name: "CONFIG_VETH"},
 		BootConfigParam{Name: "CONFIG_BRIDGE"},
 		BootConfigParam{Name: "CONFIG_BRIDGE_NETFILTER"},
-		BootConfigParam{
-			// https://cateee.net/lkddb/web-lkddb/NF_NAT_IPV4.html
-			// CONFIG_NF_NAT_IPV4 has been removed as of kernel 5.1
-			Name:             "CONFIG_NF_NAT_IPV4",
-			KernelConstraint: KernelVersionLessThan(KernelVersion{Release: 5, Major: 1}),
-		},
 		BootConfigParam{Name: "CONFIG_IP_NF_FILTER"},
 		BootConfigParam{Name: "CONFIG_IP_NF_TARGET_MASQUERADE"},
 		BootConfigParam{Name: "CONFIG_NETFILTER_XT_MATCH_ADDRTYPE"},


### PR DESCRIPTION
Removing the CONFIG_NF_NAT_IPV4 check will help avoid future
maintenance when newer kernel versions remove this config.

Specifically, RHEL 8.3 no longer offers this config after changes
from 5.1 were backported to the redhat 4.18.0-240.

(cherry picked from commit fe29d7b2c010473ab7c6b5abee8ed28f9c38acae)

Backports #285
Contributes to gravitational/gravity#2331