### PR TITLE
[master] workaround nethealth fd leak

### DIFF
--- a/lib/nethealth/nethealth.go
+++ b/lib/nethealth/nethealth.go
@@ -270,6 +270,11 @@ func (s *Server) Start() error {
 	mux := http.ServeMux{}
 	mux.Handle("/metrics", promhttp.Handler())
 	s.httpServer = &http.Server{Addr: fmt.Sprint(":", s.config.PrometheusPort), Handler: &mux}
+
+	// Workaround for https://github.com/gravitational/gravity/issues/2320
+	// Disable keep-alives to avoid the client/server hanging unix domain sockets that don't get cleaned up.
+	s.httpServer.SetKeepAlivesEnabled(false)
+
 	go func() {
 		if err := s.httpServer.ListenAndServe(); err != http.ErrServerClosed {
 			s.Fatalf("ListenAndServe(): %s", err)

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -304,6 +304,7 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 			},
 		},
 	}
+
 	// The two relevant metrics exposed by nethealth are 'nethealth_echo_request_total' and
 	// 'nethealth_echo_timeout_total'. We expect a pair of request/timeout metrics per peer.
 	// Example metrics received from nethealth may look something like the output below:
@@ -321,11 +322,16 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 		return nil, trace.Wrap(err)
 	}
 
+	req.Close = true
+
 	resp, err := client.Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusOK {
 		buffer, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Updates https://github.com/gravitational/gravity/issues/2320

Implements a workaround that appears to address the nethealth FD leak when scraping the metrics using the unix domain socket.

Broken / Leaking:
```
kevin-test1:/$ lsof -p 27303
COMMAND     PID USER   FD      TYPE             DEVICE SIZE/OFF    NODE NAME
nethealth 27303 root  cwd       DIR              0,903     4096 4098673 /
nethealth 27303 root  rtd       DIR              0,903     4096 4098673 /
nethealth 27303 root  txt       REG              0,903 33480416 5379433 /nethealth
nethealth 27303 root  mem       REG                8,1          5379433 /nethealth (stat: No such file or directory)
nethealth 27303 root  mem       REG                8,1          5133025 /usr/lib/x86_64-linux-gnu/libnss_files-2.30.so (stat: No such file or directory)
nethealth 27303 root  mem       REG                8,1          5132960 /usr/lib/x86_64-linux-gnu/libc-2.30.so (stat: No such file or directory)
nethealth 27303 root  mem       REG                8,1          5133071 /usr/lib/x86_64-linux-gnu/libpthread-2.30.so (stat: No such file or directory)
nethealth 27303 root  mem       REG                8,1          5132919 /usr/lib/x86_64-linux-gnu/ld-2.30.so (stat: No such file or directory)
nethealth 27303 root    0u      CHR                1,3      0t0       7 /dev/null
nethealth 27303 root    1w     FIFO               0,12      0t0  162501 pipe
nethealth 27303 root    2w     FIFO               0,12      0t0  162502 pipe
nethealth 27303 root    3u     sock                0,9      0t0  163922 protocol: RAW
nethealth 27303 root    4u  a_inode               0,13        0   11637 [eventpoll]
nethealth 27303 root    5u     sock                0,9      0t0  163923 protocol: UNIX
nethealth 27303 root    6u     sock                0,9      0t0  164918 protocol: TCPv6
nethealth 27303 root    7u     unix 0xffff991e95d81400      0t0  188315 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root    8u     unix 0xffff991e79d96400      0t0  189256 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root    9u     unix 0xffff991f0497b400      0t0  191381 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   10u     unix 0xffff991e9388dc00      0t0  191894 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   11u     unix 0xffff991e7513cc00      0t0  193394 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   12u     unix 0xffff991e14f16400      0t0  197822 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   13u     unix 0xffff991e91357000      0t0  193399 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   14u     unix 0xffff991e805ce400      0t0  196928 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   15u     unix 0xffff991e14f16000      0t0  199888 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   16u     unix 0xffff991e639ea400      0t0  199889 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   17u     unix 0xffff991e14f17400      0t0  201104 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   18u     unix 0xffff991e86831400      0t0  201110 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   19u     unix 0xffff991e79d96000      0t0  203329 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   20u     unix 0xffff991e79cee800      0t0  202668 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   21u     unix 0xffff991e7513e800      0t0  205262 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   22u     unix 0xffff991e95f9a800      0t0  208911 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   23u     unix 0xffff991f218be400      0t0  206147 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   24u     unix 0xffff991e98cbbc00      0t0  208146 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   25u     unix 0xffff991e7513f400      0t0  209334 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   26u     unix 0xffff991e6cb38800      0t0  210995 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   27u     unix 0xffff991e89b6d000      0t0  213021 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   28u     unix 0xffff991e869e3c00      0t0  212226 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   29u     unix 0xffff991e309aec00      0t0  212677 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   30u     unix 0xffff991e63bcc000      0t0  214537 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   31u     unix 0xffff991e1ac5b400      0t0  218173 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   32u     unix 0xffff991e1ac59c00      0t0  218182 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   33u     unix 0xffff991e1ac5a400      0t0  217668 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   34u     unix 0xffff991e1ac58c00      0t0  218603 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   35u     unix 0xffff991ef6d1dc00      0t0  221335 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   36u     unix 0xffff991e14dab400      0t0  221359 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   37u     unix 0xffff991f218be000      0t0  223444 /run/nethealth/nethealth.sock type=STREAM
nethealth 27303 root   38u     unix 0xffff991e1ac5a000      0t0  223455 /run/nethealth/nethealth.sock type=STREAM
```

After changes:
```
root@kevin-test1:~/build# gravity exec lsof -p `gravity exec pidof /usr/bin/planet` | grep unix
planet  1063 root    1u     unix 0xffff991f1b743400      0t0  32382 type=STREAM
planet  1063 root    2u     unix 0xffff991f1b743400      0t0  32382 type=STREAM
planet  1063 root    3u     unix 0xffff991f055cc000      0t0  31578 type=DGRAM
planet  1063 root    5u     unix 0xffff991f2a47f000      0t0  33021 type=STREAM
planet  1063 root    6u     unix 0xffff991f055cc800      0t0  31584 type=DGRAM
planet  1063 root   12u     unix 0xffff991f2a47cc00      0t0  33019 type=STREAM
planet  1063 root   24u     unix 0xffff991e7b84d800      0t0  74021 type=STREAM
planet  1063 root   27u     unix 0xffff991e14eaac00      0t0 108823 type=STREAM

root@kevin-test1:~/build# gravity exec lsof -p `gravity exec pidof /nethealth`
COMMAND     PID USER   FD      TYPE DEVICE SIZE/OFF    NODE NAME
nethealth 26367 root  cwd       DIR  0,903     4096 4100850 /
nethealth 26367 root  rtd       DIR  0,903     4096 4100850 /
nethealth 26367 root  txt       REG  0,903 28913664 4100848 /nethealth
nethealth 26367 root  mem       REG    8,1          4100848 /nethealth (stat: No such file or directory)
nethealth 26367 root  mem       REG    8,1          4100366 /lib/x86_64-linux-gnu/libnss_files-2.28.so (stat: No such file or directory)
nethealth 26367 root  mem       REG    8,1          4100363 /lib/x86_64-linux-gnu/libnsl-2.28.so (stat: No such file or directory)
nethealth 26367 root  mem       REG    8,1          4100368 /lib/x86_64-linux-gnu/libnss_nis-2.28.so (stat: No such file or directory)
nethealth 26367 root  mem       REG    8,1          4100364 /lib/x86_64-linux-gnu/libnss_compat-2.28.so (stat: No such file or directory)
nethealth 26367 root  mem       REG    8,1          4100357 /lib/x86_64-linux-gnu/libc-2.28.so (stat: No such file or directory)
nethealth 26367 root  mem       REG    8,1          4100371 /lib/x86_64-linux-gnu/libpthread-2.28.so (stat: No such file or directory)
nethealth 26367 root  mem       REG    8,1          4100353 /lib/x86_64-linux-gnu/ld-2.28.so (stat: No such file or directory)
nethealth 26367 root    0u      CHR    1,3      0t0       7 /dev/null
nethealth 26367 root    1w     FIFO   0,12      0t0  292301 pipe
nethealth 26367 root    2w     FIFO   0,12      0t0  292302 pipe
nethealth 26367 root    3u  a_inode   0,13        0   11637 [eventpoll]
nethealth 26367 root    4u     sock    0,9      0t0  291228 protocol: RAW
nethealth 26367 root    5r     FIFO   0,12      0t0  289761 pipe
nethealth 26367 root    6w     FIFO   0,12      0t0  289761 pipe
nethealth 26367 root    7u     sock    0,9      0t0  291229 protocol: UNIX
nethealth 26367 root    8u     sock    0,9      0t0  290300 protocol: TCPv6
```
```
