### PR TITLE
[7.0] workaround nethealth fd leak (#291)

### DIFF
--- a/lib/nethealth/nethealth.go
+++ b/lib/nethealth/nethealth.go
@@ -242,6 +242,11 @@ func (s *Server) Start() error {
 	mux := http.ServeMux{}
 	mux.Handle("/metrics", promhttp.Handler())
 	s.httpServer = &http.Server{Addr: fmt.Sprint(":", s.config.PrometheusPort), Handler: &mux}
+
+	// Workaround for https://github.com/gravitational/gravity/issues/2320
+	// Disable keep-alives to avoid the client/server hanging unix domain sockets that don't get cleaned up.
+	s.httpServer.SetKeepAlivesEnabled(false)
+
 	go func() {
 		if err := s.httpServer.ListenAndServe(); err != http.ErrServerClosed {
 			s.Fatalf("ListenAndServe(): %s", err)

--- a/monitoring/nethealth.go
+++ b/monitoring/nethealth.go
@@ -306,6 +306,7 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 		},
 		Timeout: time.Second,
 	}
+
 	// The two relevant metrics exposed by nethealth are 'nethealth_echo_request_total' and
 	// 'nethealth_echo_timeout_total'. We expect a pair of request/timeout metrics per peer.
 	// Example metrics received from nethealth may look something like the output below:
@@ -325,11 +326,16 @@ func (c *nethealthChecker) fetchNethealthMetrics(ctx context.Context) (res []byt
 
 	req = req.WithContext(ctx)
 
+	req.Close = true
+
 	resp, err := client.Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusOK {
 		buffer, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Backport #291 

* try adjusting client on unix domain sockets to avoid fd leak

* workaround for fd leak in grabbing metrics over unix socket

(cherry picked from commit 0622d0257e681a21305dbc58b35313572bc782ce)