### PR TITLE
[master] g1k scaling satellite

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -501,10 +501,6 @@ func (r *agent) statusUpdateLoop(ctx context.Context) error {
 	ticker := r.Clock.NewTicker(StatusUpdateTimeout)
 	defer ticker.Stop()
 
-	if err := r.updateStatus(ctx); err != nil {
-		log.WithError(err).Warn("Failed to updates status.")
-	}
-
 	for {
 		select {
 		case <-ticker.Chan():

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -137,9 +137,13 @@ func (r *Config) CheckAndSetDefaults() error {
 	if r.Clock == nil {
 		r.Clock = clockwork.NewRealClock()
 	}
+
+	if r.clientCache == nil {
+		r.clientCache = &client.ClientCache{}
+	}
+
 	if r.DialRPC == nil {
-		cache := &client.ClientCache{}
-		r.DialRPC = cache.DefaultDialRPC(r.CAFile, r.CertFile, r.KeyFile)
+		r.DialRPC = r.clientCache.DefaultDialRPC(r.CAFile, r.CertFile, r.KeyFile)
 	}
 	return nil
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -556,8 +556,6 @@ func (r *agent) collectStatus(ctx context.Context) *pb.SystemStatus {
 		}
 	}
 
-	go r.clientCache.CloseMissingMembers(members, StatusUpdateTimeout-time.Second)
-
 	systemStatus := &pb.SystemStatus{
 		Status:    pb.SystemStatus_Unknown,
 		Timestamp: pb.NewTimeToProto(r.Clock.Now()),
@@ -605,6 +603,8 @@ L:
 	}
 
 	setSystemStatus(systemStatus, members)
+
+	go r.clientCache.CloseMissingMembers(members)
 
 	return systemStatus
 }

--- a/agent/constants.go
+++ b/agent/constants.go
@@ -69,16 +69,21 @@ const (
 	// status query reply.
 	statusQueryReplyTimeout = 30 * time.Second
 
-	// nodeStatusTimeout specifies the amount of time to wait for a node status
+	// nodeStatusTimeoutLocal specifies the amount of time to wait for a node status
 	// query reply. The timeout is smaller than the statusQueryReplyTimeout so
 	// that the node status collection step can return results before the
 	// deadline.
-	nodeStatusTimeout = statusQueryReplyTimeout - (5 * time.Second)
+	nodeStatusTimeoutLocal = statusQueryReplyTimeout - (5 * time.Second)
+
+	// nodestatusTimeoutRemote specifies the amount of time to wait for a node status from a remote node.
+	// This timeout is set low, because the remote node pre-caches the status, and as such is expected to respond
+	// quickly.
+	nodeStatusTimeoutRemote = time.Second
 
 	// checksTimeout specifies the amount of time to wait for a check to complete.
 	// The checksTimeout is smaller than the nodeStatusTimeout so that the checks
 	// can return results before the deadline.
-	checksTimeout = nodeStatusTimeout - (5 * time.Second)
+	checksTimeout = nodeStatusTimeoutLocal - (5 * time.Second)
 
 	// probeTimeout specifies the amount of time to wait for a probe to complete.
 	// The probeTimeout is smaller than the checksTimeout so that the probe

--- a/lib/rpc/client/client.go
+++ b/lib/rpc/client/client.go
@@ -248,7 +248,7 @@ func (c *ClientCache) DefaultDialRPC(caFile, certFile, keyFile string) DialRPC {
 			CertFile: certFile,
 			KeyFile:  keyFile,
 		}
-		client, err := NewClient(ctx, config)
+		client, err := NewClient(context.Background(), config)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/rpc/client/client.go
+++ b/lib/rpc/client/client.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"sync"
-	"time"
 
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
 	debugpb "github.com/gravitational/satellite/agent/proto/debug"
@@ -281,9 +280,7 @@ func (c *ClientCache) getClientFromCache(addr string) Client {
 
 // CloseMissingMembers will removed gRPC clients from the cache that don't appear to be part
 // of the cluster. It will do so after sleeping for the provided timeout.
-func (c *ClientCache) CloseMissingMembers(currentMembers []*pb.MemberStatus, sleep time.Duration) {
-	time.Sleep(sleep)
-
+func (c *ClientCache) CloseMissingMembers(currentMembers []*pb.MemberStatus) {
 	currentMap := make(map[string]interface{})
 
 	for _, member := range currentMembers {

--- a/lib/rpc/client/client.go
+++ b/lib/rpc/client/client.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/satellite/lib/rpc"
 
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -227,6 +228,8 @@ func (r *client) Close() error {
 // DialRPC returns RPC client for the provided addr.
 type DialRPC func(ctx context.Context, addr string) (Client, error)
 
+// ClientCache provides a caching mechanism to re-use Clients to peers without the expense of establishing new
+// transport connections every time a peer is dialed.
 type ClientCache struct {
 	sync.RWMutex
 	clients map[string]Client
@@ -234,6 +237,8 @@ type ClientCache struct {
 
 // DefaultDialRPC is the default RPC client factory function.
 // It creates a new client based on address details.
+// Note: the passed in context governs the context for the gRPC session, and as such should only be cancelled if we
+// want the underlying gRPC connection to shutdown.
 func (c *ClientCache) DefaultDialRPC(caFile, certFile, keyFile string) DialRPC {
 	return func(ctx context.Context, addr string) (Client, error) {
 		client := c.getClientFromCache(addr)
@@ -253,11 +258,24 @@ func (c *ClientCache) DefaultDialRPC(caFile, certFile, keyFile string) DialRPC {
 		}
 
 		c.Lock()
+		defer c.Unlock()
+
 		if c.clients == nil {
 			c.clients = make(map[string]Client)
 		}
+
+		// if another routine raced us, return the other routines client and shutdown ours
+		if c, ok := c.clients[addr]; ok {
+			err := client.Close()
+			if err != nil {
+				logrus.WithError(err).Debug("closing gRPC client error")
+				// fallthrough, we don't care if closing the client failed
+			}
+
+			return c, nil
+		}
+
 		c.clients[addr] = client
-		c.Unlock()
 
 		return client, nil
 	}
@@ -302,6 +320,10 @@ func (c *ClientCache) CloseMissingMembers(currentMembers []*pb.MemberStatus) {
 	c.Unlock()
 
 	for _, client := range removed {
-		client.Close()
+		err := client.Close()
+		if err != nil {
+			logrus.WithError(err).Debug("closing gRPC client error")
+			// fallthrough, we don't care if closing the client failed
+		}
 	}
 }

--- a/monitoring/latency/latency.go
+++ b/monitoring/latency/latency.go
@@ -184,8 +184,7 @@ func (r *checker) verifyLatency(summaries map[string]*dto.Summary, node string, 
 	}
 }
 
-// latencyAtQuantile returns the latency at the specified quantile. Latency
-// is returned in milliseconds.
+// latencyAtQuantile returns the latency at the specified quantile.
 // Returns NotFound if latency is not available at the specified quantile.
 func latencyAtQuantile(summary *dto.Summary, quantile float64) (latency time.Duration, err error) {
 	for _, q := range summary.GetQuantile() {


### PR DESCRIPTION
This is some tuning to satellite behaviour when testing large clusters. Basically, with a large number of errors or interruptions, such as 325/1000 nodes being network isolated as if there was an availability zone failure, satellite status could be unreliable, which appeared to lots of dial timeouts and the expense of establishing TLS connections within the cycle.

So this tuning basically does:
1. Do not wait very long for collecting status from peers, timeout very quickly since this should just be collecting cached information.
2. Rewrite caching code to cache all gRPC calls and not just the timedrift code.

Testing:
1. Create 1000 node cluster.
2. Create network fault that isolates approx 1/3 of nodes (I introduced a network ACL on the AWS subnet).
3. Verify that node failures are correctly reported on approx 1/3 of nodes (take up to 90 seconds).
4. Introduce a fault on a node still part of the working cluster (I unloaded the br_netfilter module).
5. Ensure that alarm shows up within 90 seconds. Remove the fault.
6. Remove the network acl blocking one AZ.
7. Verify that all nodes re-establish an online state (takes up to 90 seconds).

