### PR TITLE
Remove deprecated ComponentStatuses API

### DIFF
--- a/cmd/agent/checkers.go
+++ b/cmd/agent/checkers.go
@@ -88,7 +88,7 @@ func addToMaster(node agent.Agent, config *config, kubeConfig monitoring.KubeCon
 		return trace.Wrap(err)
 	}
 
-	node.AddChecker(monitoring.KubeAPIServerHealth(kubeConfig))
+	node.AddChecker(monitoring.KubeComponentsHealth(monitoring.DefaultLocalComponentHealthzConfig))
 	node.AddChecker(monitoring.DockerHealth(config.dockerAddr))
 	node.AddChecker(etcdChecker)
 	node.AddChecker(monitoring.SystemdHealth())
@@ -106,7 +106,7 @@ func addToNode(node agent.Agent, config *config) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	node.AddChecker(monitoring.KubeletHealth(config.kubeletAddr))
+	node.AddChecker(monitoring.KubeletHealth(monitoring.DefaultLocalKubeletHealthzAddr))
 	node.AddChecker(monitoring.DockerHealth(config.dockerAddr))
 	node.AddChecker(etcdChecker)
 	node.AddChecker(monitoring.SystemdHealth())

--- a/healthz/checks/checks.go
+++ b/healthz/checks/checks.go
@@ -44,7 +44,7 @@ func NewRunner(kubeConfig monitoring.KubeConfig, kubeNodesReadyThreshold int, et
 	}
 	runner := &Runner{}
 	runner.AddChecker(etcdChecker)
-	runner.AddChecker(monitoring.KubeAPIServerHealth(kubeConfig))
+	runner.AddChecker(monitoring.KubeComponentsHealth(monitoring.DefaultLocalComponentHealthzConfig))
 	runner.AddChecker(monitoring.NodesStatusHealth(kubeConfig, kubeNodesReadyThreshold))
 	return runner, nil
 }

--- a/monitoring/checkers.go
+++ b/monitoring/checkers.go
@@ -22,36 +22,21 @@ import (
 
 	"github.com/gravitational/satellite/agent/health"
 	"github.com/gravitational/trace"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kube "k8s.io/client-go/kubernetes"
 )
 
-// healthzChecker is secure healthz checker
-type healthzChecker struct {
-	*KubeChecker
-}
-
-// KubeAPIServerHealth creates a checker for the kubernetes API server
-func KubeAPIServerHealth(config KubeConfig) health.Checker {
-	checker := &healthzChecker{}
-	kubeChecker := &KubeChecker{
-		name:    "kube-apiserver",
-		checker: checker.testHealthz,
-		client:  config.Client,
-	}
-	checker.KubeChecker = kubeChecker
-	return kubeChecker
-}
-
-// testHealthz executes a test by using k8s API
-func (h *healthzChecker) testHealthz(ctx context.Context, client *kube.Clientset) error {
-	_, err := client.CoreV1().ComponentStatuses().Get(ctx, "scheduler", metav1.GetOptions{})
-	return err
+// KubeComponentsHealth creates a composite checker for kubernetes control plane components
+func KubeComponentsHealth(config ComponentHealthzConfig) health.Checker {
+	return NewCompositeChecker("kube-components",
+		[]health.Checker{
+			NewHTTPHealthzChecker("kube-scheduler", config.SchedulerAddr, kubeHealthz),
+			NewHTTPHealthzChecker("kube-controller-manager", config.ControllerManagerAddr, kubeHealthz),
+		},
+	)
 }
 
 // KubeletHealth creates a checker for the kubernetes kubelet component
 func KubeletHealth(addr string) health.Checker {
-	return NewHTTPHealthzChecker("kubelet", fmt.Sprintf("%v/healthz", addr), kubeHealthz)
+	return NewHTTPHealthzChecker("kubelet", addr, kubeHealthz)
 }
 
 // NodesStatusHealth creates a checker that reports a number of ready kubernetes nodes
@@ -111,6 +96,14 @@ func SystemdHealth() health.Checker {
 // by scheduling pods and verifying the communication
 func InterPodCommunication(config KubeConfig, nettestImage string) health.Checker {
 	return NewInterPodChecker(config, nettestImage)
+}
+
+func localSecureHealthzAddr(port int) string {
+	return fmt.Sprintf("https://127.0.0.1:%d/healthz", port)
+}
+
+func localHealthzAddr(port int) string {
+	return fmt.Sprintf("http://127.0.0.1:%d/healthz", port)
 }
 
 func (_ noopChecker) Name() string                           { return "noop" }

--- a/monitoring/kubernetes.go
+++ b/monitoring/kubernetes.go
@@ -35,6 +35,34 @@ type KubeConfig struct {
 	Client *kube.Clientset
 }
 
+// ComponentHealthzConfig describes control plane component healthz access details
+type ComponentHealthzConfig struct {
+	// SchedulerAddr defines the healthz address of the kube-scheduler
+	SchedulerAddr string
+	// ControllerManagerPort defines the healthz address of the kube-controller-manager
+	ControllerManagerAddr string
+}
+
+// DefaultLocalComponentHealthzConfig defines the default component healthz configuration on localhsot
+var DefaultLocalComponentHealthzConfig = ComponentHealthzConfig{
+	SchedulerAddr:         localSecureHealthzAddr(DefaultKubeSchedulerHealthzPort),
+	ControllerManagerAddr: localSecureHealthzAddr(DefaultKubeControllerManagerHealthzPort),
+}
+
+// DefaultLocalKubeletHealthzAddr is the default kubelet healthz address on localhost
+var DefaultLocalKubeletHealthzAddr = localHealthzAddr(DefaultKubeletHealthzPort)
+
+const (
+	// DefaultKubeletHealthzPort specifies the default kubelet healthz endpoint port
+	DefaultKubeletHealthzPort = 10248
+
+	// DefaultKubeSchedulerHealthzPort specifies the default kubelet healthz endpoint port
+	DefaultKubeSchedulerHealthzPort = 10259
+
+	// DefaultKubeControllerManagerHealthzPort specifies the default kubelet healthz endpoint port
+	DefaultKubeControllerManagerHealthzPort = 10257
+)
+
 // kubeHealthz is httpResponseChecker that interprets health status of common kubernetes services.
 func kubeHealthz(response io.Reader) error {
 	payload, err := ioutil.ReadAll(response)

--- a/monitoring/kubernetes.go
+++ b/monitoring/kubernetes.go
@@ -56,10 +56,10 @@ const (
 	// DefaultKubeletHealthzPort specifies the default kubelet healthz endpoint port
 	DefaultKubeletHealthzPort = 10248
 
-	// DefaultKubeSchedulerHealthzPort specifies the default kubelet healthz endpoint port
+	// DefaultKubeSchedulerHealthzPort specifies the default scheduler healthz endpoint port
 	DefaultKubeSchedulerHealthzPort = 10259
 
-	// DefaultKubeControllerManagerHealthzPort specifies the default kubelet healthz endpoint port
+	// DefaultKubeControllerManagerHealthzPort specifies the default controller manager healthz endpoint port
 	DefaultKubeControllerManagerHealthzPort = 10257
 )
 


### PR DESCRIPTION
Follow up to https://github.com/gravitational/gravity/pull/2562 removing the ComponentStatuses API from satellite and consequently from planet.