### PR TITLE
Prepare satellite repo for archive

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,35 +1,4 @@
 # Contributing
 
-Satellite is an open source project.
-
-It is the work of many contributors. We appreciate your help!
-
-We follow a [code of conduct](./CODE_OF_CONDUCT.md).
-
-## Filing an Issue
-
-Security issues should be reported directly to security@goteleport.com.
-
-Satellite uses [Gravity's issue tracker]((https://github.com/gravitational/gravity/issues).
-
-If you are unsure if you've found a bug, search the tracker first.
-
-Once you know you have a issue, fill out all sections of the
-one of the templates at https://github.com/gravitational/gravity/issues/new/choose.
-
-Gravity contributors will triage the issue.
-
-## Contributing A Patch
-
-If you're working on an existing issue, respond to the issue and express
-interest in working on it. This helps other people know that the issue is
-active, and hopefully prevents duplicated efforts.
-
-If you want to work on a new idea of relatively small scope:
-
-1. Submit an issue describing the proposed change and the implementation.
-2. The repo owners will respond to your issue promptly.
-3. Write your code, test your changes and _communicate_ with us as you're
-moving forward.
-4. Submit a pull request from your fork.
+Satellite is not currently accepting contributions.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Satellite
 
+> **Warning**
+> Satellite was archived 2023-07-01.
+>
+> Please see the [Gravity](https://github.com/gravitational/gravity) README.md for more information.
+
+
 Satellite is an agent collecting health information in a [Kubernetes](https://github.com/kubernetes/kubernetes) cluster.
 It is both a library and an application. As a library, satellite can be used as a basis for a custom monitoring solution.
 
@@ -131,11 +137,6 @@ $ satellite agent --tags=role:master \
 	--influxdb-database=monitoring \
 	--influxdb-url=http://localhost:8086
 ```
-
-## Developing & Contributing
-
-We follow a [Code of Conduct](./CODE_OF_CONDUCT.md). We also have [contributing guidelines](./CONTRIBUTING.md)
-with information about filing bugs and submitting patches.
 
 ### Building from source
 


### PR DESCRIPTION
The entire gravity project is being shut down at the top of July.

I'm editing the README's of some of the more popular components (planet, satellite) but I probably wont go much further than that.

See https://github.com/gravitational/gravity/pull/2775